### PR TITLE
feat: add short selling and covering functionality in FundPaperTrader

### DIFF
--- a/backend/api/funds.py
+++ b/backend/api/funds.py
@@ -357,3 +357,43 @@ async def clear_funds():
             "success": False,
             "message": f"清空基金列表失败: {str(e)}"
         }
+
+
+@router.get(
+    "/{fund_code}/nav-history",
+    summary="获取基金净值历史",
+    description="获取指定基金的净值历史数据（用于净值走势图）"
+)
+async def get_fund_nav_history(fund_code: str, limit: int = 250):
+    """
+    获取基金净值历史
+
+    - **fund_code**: 基金代码
+    - **limit**: 返回最近多少条记录（默认 250）
+    """
+    try:
+        from ..fund_quant.data.storage import get_nav_history
+        nav_data = await asyncio.to_thread(get_nav_history, fund_code)
+        if not nav_data:
+            # 尝试采集
+            try:
+                from ..fund_quant.data.collector import fund_data_collector
+                from ..fund_quant.data.storage import save_nav_points
+                points = await fund_data_collector.fetch_nav_history(
+                    fund_code=fund_code,
+                    start_date=(datetime.now() - timedelta(days=365 * 5)).strftime("%Y%m%d"),
+                )
+                if points:
+                    await asyncio.to_thread(save_nav_points, points)
+                    nav_data = await asyncio.to_thread(get_nav_history, fund_code)
+            except Exception as e:
+                logger.warning(f"自动采集净值失败 {fund_code}: {e}")
+
+        if not nav_data:
+            return {"success": False, "message": f"基金 {fund_code} 无净值数据", "data": []}
+
+        recent = nav_data[-limit:] if len(nav_data) > limit else nav_data
+        return {"success": True, "data": recent}
+    except Exception as e:
+        logger.error(f"获取净值历史失败: {fund_code}, {e}")
+        return {"success": False, "message": f"获取净值历史失败: {str(e)}", "data": []}

--- a/backend/api/valuation.py
+++ b/backend/api/valuation.py
@@ -238,6 +238,8 @@ async def get_fund_valuation_batch_stream(request: ValuationBatchRequest):
                             "valuation_signal": result.valuation_signal,
                             "signal_action": result.signal_action,
                             "signal_source": result.signal_source,
+                            "iopv": result.iopv,
+                            "premium_percent": result.premium_percent,
                             "timestamp": result.timestamp.isoformat()
                             if result.timestamp
                             else None,

--- a/backend/fund_quant/backtest/engine.py
+++ b/backend/fund_quant/backtest/engine.py
@@ -18,21 +18,29 @@ from .disclosure import DisclosureCalendar
 
 
 class SimPosition:
-    """模拟持仓"""
-    def __init__(self, fund_code: str, shares: float, buy_date: date, buy_nav: float):
+    """模拟持仓（支持多空）"""
+    def __init__(self, fund_code: str, shares: float, buy_date: date, buy_nav: float,
+                 direction: str = "long"):
         self.fund_code = fund_code
         self.shares = shares
         self.buy_date = buy_date
         self.buy_nav = buy_nav
         self.cost = shares * buy_nav
+        self.direction = direction  # "long" 或 "short"
 
     def current_value(self, nav: float) -> float:
+        """持仓市值（空头为负值，表示负债）"""
+        if self.direction == "short":
+            return -self.shares * nav
         return self.shares * nav
 
     def holding_days(self, current_date: date) -> int:
         return (current_date - self.buy_date).days
 
     def pnl(self, nav: float) -> float:
+        """未实现盈亏（多头=nav-buy_nav, 空头=buy_nav-nav）"""
+        if self.direction == "short":
+            return self.shares * (self.buy_nav - nav)
         return self.shares * (nav - self.buy_nav)
 
 
@@ -323,13 +331,40 @@ class FundBacktester:
             pos = self._positions.get(sig.fund_code)
             if pos is None:
                 return
-            pct = sig.suggested_pct
+            pct = abs(sig.suggested_pct) if sig.suggested_pct is not None else None
             if pct is None:
                 pct = 1.0  # 默认全卖
             shares = pos.shares * pct
             if shares > 0:
                 self.submit_order(sig.fund_code, "sell", shares, current_date, 1)
                 logger.debug(f"下单卖出 {sig.fund_code}: {shares:.2f}份")
+
+        elif sig.direction == Direction.SHORT.value or sig.direction == Direction.SHORT:
+            # 做空开仓（融券卖出）：无持仓也可卖
+            target_amt = sig.suggested_amount
+            if target_amt is None and sig.suggested_pct is not None:
+                target_amt = abs(sig.suggested_pct) * total
+            if target_amt is None:
+                target_amt = total * 0.1
+            if target_amt <= 0:
+                return
+            shares = target_amt / nav_price
+            if shares > 0:
+                self.submit_order(sig.fund_code, "short", shares, current_date, 1)
+                logger.debug(f"下单做空 {sig.fund_code}: {shares:.2f}份 @ {nav_price}")
+
+        elif sig.direction == Direction.CLOSE_SHORT.value or sig.direction == Direction.CLOSE_SHORT:
+            # 做空平仓（买券还券）：减少空头仓位
+            pos = self._positions.get(sig.fund_code)
+            if pos is None or pos.direction != "short":
+                return
+            pct = abs(sig.suggested_pct) if sig.suggested_pct is not None else None
+            if pct is None:
+                pct = 1.0
+            shares = pos.shares * pct
+            if shares > 0:
+                self.submit_order(sig.fund_code, "cover", shares, current_date, 1)
+                logger.debug(f"下单平空 {sig.fund_code}: {shares:.2f}份 @ {nav_price}")
 
         elif sig.direction == Direction.REBALANCE.value or sig.direction == Direction.REBALANCE:
             # 再平衡: 由 strategy 负责给出每个基金的买卖信号
@@ -390,6 +425,59 @@ class FundBacktester:
                         "cost": round(cost, 2),
                         "nav_date": confirm_key,
                     })
+            elif order.order_type == "short":
+                # 做空开仓（融券卖出）：获得资金 + 建空头
+                proceeds = order.shares * nav_price
+                self._cash += proceeds
+                existing = self._positions.get(order.fund_code)
+                if existing and existing.direction == "short":
+                    # 空头加仓（合并）：负债总额 = 原负债 + 新卖券所得
+                    total_shares = existing.shares + order.shares
+                    total_liability = existing.cost + proceeds
+                    avg_nav = total_liability / total_shares if total_shares > 0 else 0
+                    self._positions[order.fund_code] = SimPosition(
+                        order.fund_code, total_shares, existing.buy_date, avg_nav, direction="short",
+                    )
+                else:
+                    self._positions[order.fund_code] = SimPosition(
+                        order.fund_code, order.shares, order.submit_date, nav_price, direction="short",
+                    )
+                self._trade_log.append({
+                    "date": current_date.isoformat(),
+                    "fund_code": order.fund_code,
+                    "action": "short_confirmed",
+                    "shares": order.shares,
+                    "price": nav_price,
+                    "proceeds": round(proceeds, 2),
+                    "nav_date": confirm_key,
+                })
+            elif order.order_type == "cover":
+                # 做空平仓（买券还券）：付出资金 + 减少空头
+                cost = order.shares * nav_price
+                pos = self._positions.get(order.fund_code)
+                if pos is None or pos.direction != "short":
+                    still_pending.append(order)
+                    continue
+                if cost > self._cash:
+                    still_pending.append(order)  # 资金不足，延迟到有资金时平仓
+                    continue
+                self._cash -= cost
+                remaining = pos.shares - order.shares
+                if remaining <= 0:
+                    del self._positions[order.fund_code]
+                else:
+                    sell_ratio = order.shares / pos.shares
+                    pos.cost *= (1 - sell_ratio)
+                    pos.shares = remaining
+                self._trade_log.append({
+                    "date": current_date.isoformat(),
+                    "fund_code": order.fund_code,
+                    "action": "cover_confirmed",
+                    "shares": order.shares,
+                    "price": nav_price,
+                    "cost": round(cost, 2),
+                    "nav_date": confirm_key,
+                })
             elif order.order_type == "sell":
                 # 巨额赎回限制检查
                 total_shares = self._calc_fund_total_shares(order.fund_code)
@@ -573,7 +661,7 @@ class FundBacktester:
 
     def _calc_total_value(self, date_str: str,
                            code_nav_map: Dict[str, Dict[str, dict]]) -> float:
-        """计算组合总价值"""
+        """计算组合总价值（支持多空持仓）"""
         total = self._cash
         for code, pos in self._positions.items():
             nav_data = None
@@ -582,7 +670,7 @@ class FundBacktester:
                     nav_data = nm.get(date_str)
                     break
             cur_nav = nav_data.get("nav", pos.buy_nav) if nav_data else pos.buy_nav
-            total += pos.shares * cur_nav
+            total += pos.current_value(cur_nav)
         return total
 
     def submit_order(self, fund_code: str, order_type: str,
@@ -779,7 +867,7 @@ def _build_portfolio_snapshot(positions, cash, total) -> "Portfolio":
     """构建策略可读的 Portfolio 快照 (Dict[str, float]: fund_code -> weight)"""
     from ..core.models import Portfolio
     pos_dict = {
-        code: (p.shares * p.buy_nav) / total if total > 0 else 0
+        code: (p.shares * p.buy_nav * (1 if p.direction != "short" else -1)) / total if total > 0 else 0
         for code, p in positions.items()
     }
     return Portfolio(
@@ -796,6 +884,8 @@ def _signal_to_core(sig) -> Any:
         dir_map = {
             "buy": CoreDir.LONG,
             "sell": CoreDir.CLOSE_LONG,
+            "short": CoreDir.SHORT,
+            "close_short": CoreDir.CLOSE_SHORT,
             "hold": CoreDir.NONE,
         }
         d = sig.direction.value if hasattr(sig.direction, 'value') else sig.direction

--- a/backend/fund_quant/backtest/paper_trader.py
+++ b/backend/fund_quant/backtest/paper_trader.py
@@ -285,6 +285,43 @@ class FundPaperTrader:
                         "date": today.isoformat(),
                         "status": "confirmed",
                     })
+            elif direction == "short":
+                # 做空开仓（融券卖出）：获得资金 + 建空头（负仓位）
+                proceeds = round(shares * nav, 2)
+                state.cash += proceeds
+                state.positions[code] = state.positions.get(code, 0.0) - shares
+                state.trade_log.append({
+                    "fund_code": code,
+                    "direction": "short",
+                    "shares": shares,
+                    "nav": nav,
+                    "amount": proceeds,
+                    "date": today.isoformat(),
+                    "status": "confirmed",
+                })
+            elif direction == "cover":
+                # 做空平仓（买券还券）：付出资金 + 减少空头（负仓位变正）
+                held_short = max(-state.positions.get(code, 0.0), 0.0)
+                actual = min(shares, held_short)
+                if actual <= 0:
+                    confirmed.append(order)
+                    continue
+                cost = round(actual * nav, 2)
+                if cost > state.cash:
+                    continue  # 资金不足，延迟平仓
+                state.cash -= cost
+                state.positions[code] = state.positions.get(code, 0.0) + actual
+                if abs(state.positions[code]) < 1e-9:
+                    del state.positions[code]
+                state.trade_log.append({
+                    "fund_code": code,
+                    "direction": "cover",
+                    "shares": actual,
+                    "nav": nav,
+                    "amount": cost,
+                    "date": today.isoformat(),
+                    "status": "confirmed",
+                })
             elif direction == "buy":
                 cost = round(shares * nav, 2)
                 if cost <= state.cash:
@@ -334,6 +371,7 @@ class FundPaperTrader:
         for code, shares in state.positions.items():
             nav = navs.get(code)
             if nav:
+                # 空头为负仓位（负债），多头正仓位
                 total += shares * nav
         return total
 

--- a/backend/fund_quant/core/enums.py
+++ b/backend/fund_quant/core/enums.py
@@ -17,6 +17,8 @@ class Direction(str, Enum):
     SELL = "sell"
     HOLD = "hold"
     REBALANCE = "rebalance"
+    SHORT = "short"          # 做空开仓（融券卖出）
+    CLOSE_SHORT = "close_short"  # 做空平仓（买券还券）
 
 
 class FundType(str, Enum):

--- a/backend/fund_quant/strategy/timing/valuation_deviation.py
+++ b/backend/fund_quant/strategy/timing/valuation_deviation.py
@@ -18,6 +18,7 @@ class ValuationDeviationStrategy(FundStrategyBase):
         "lookback_days": 60,
         "momentum_confirm_days": 3,
         "cooldown_days": 5,
+        "allow_short": False,  # 高估时是否发 SHORT 做空信号（仅场内ETF有效）
     }
     param_ranges = {
         "z_threshold": {"min": 1.0, "max": 3.0},
@@ -68,10 +69,10 @@ class ValuationDeviationStrategy(FundStrategyBase):
 
         # 方向判定 (均值回归逻辑)
         if z_score > z_threshold:
-            # 偏差偏高, 预期回归 → 卖出
-            direction = Direction.SELL
+            # 偏差偏高, 预期回归 → 卖出或做空
+            direction = Direction.SHORT if self.params.get("allow_short") else Direction.SELL
             reason = (f"估值偏差偏高 (z={z_score:.2f} > {z_threshold}), "
-                      f"预期净值回落, 建议减仓")
+                      f"{'预期净值回落, 建议做空' if self.params.get('allow_short') else '预期净值回落, 建议减仓'}")
         elif z_score < -z_threshold:
             # 偏差偏低, 预期反弹 → 买入
             direction = Direction.BUY

--- a/backend/fund_valuation.py
+++ b/backend/fund_valuation.py
@@ -743,6 +743,8 @@ class FundValuationService:
                 confidence=1.0,
                 confidence_note="场内ETF实时价格，100%准确",
                 timestamp=datetime.now(),
+                iopv=realtime_data.get("iopv"),
+                premium_percent=realtime_data.get("premium_percent"),
             )
         except Exception as e:
             logger.exception(f"ETF 估值计算异常 {fund_code}: {e}")
@@ -1848,6 +1850,19 @@ class FundValuationService:
                 result.valuation_signal = signal_data.get("signal")
                 result.signal_action = signal_data.get("signal_action")
                 result.signal_source = signal_data.get("source", "")
+
+        # 场内基金统一附加折溢价（包括 QDII ETF 等走 index_based 路径的）
+        if result and result.premium_percent is None:
+            try:
+                mkt = await market_data_service.get_fund_data(fund_code)
+                if mkt and mkt.market_type == MarketType.ON_EXCHANGE:
+                    etf_data = await market_data_service.get_etf_realtime_data(fund_code)
+                    if etf_data:
+                        result.iopv = etf_data.get("iopv")
+                        result.premium_percent = etf_data.get("premium_percent")
+            except Exception:
+                pass
+
         return result
 
 

--- a/backend/market_data.py
+++ b/backend/market_data.py
@@ -2247,7 +2247,7 @@ class ETFPriceAPI:
             logger.debug(f"ETF {code} 使用缓存数据（TTL={ttl}s）")
             return cached_data
 
-        # ===== 数据源 1: 腾讯财经 API (最稳定) =====
+        # ===== 数据源 1: 腾讯财经 API (最稳定，且自带 IOPV 可算折溢价) =====
         try:
             # 腾讯 API 格式：sh510300, sz159915
             exchange = 'sh' if code.startswith('51') or code.startswith('50') else 'sz'
@@ -2255,6 +2255,7 @@ class ETFPriceAPI:
             content = await self._request_with_retry("GET", url, timeout=aiohttp.ClientTimeout(total=5.0))
             if content:
                 # 解析腾讯格式：v_sh510300="1~名称~代码~price~previous_close~..."
+                # ETF 完整 88 字段格式中，位置 78 为 IOPV 实时估值（如无则跳过折溢价）
                 match = re.search(r'"([^"]+)"', content)
                 if match:
                     parts = match.group(1).split("~")
@@ -2265,6 +2266,17 @@ class ETFPriceAPI:
                         change = price - previous_close
                         change_percent = (change / previous_close * 100) if previous_close else 0
 
+                        # IOPV → 折溢价率（溢价为正 = 市价高于净值）
+                        iopv = None
+                        premium_percent = None
+                        if len(parts) > 78 and parts[78]:
+                            try:
+                                iopv = float(parts[78])
+                                if iopv > 0:
+                                    premium_percent = round((price - iopv) / iopv * 100, 2)
+                            except ValueError:
+                                pass
+
                         result = {
                             "code": code,
                             "name": name,
@@ -2272,6 +2284,8 @@ class ETFPriceAPI:
                             "change": change,
                             "change_percent": round(change_percent, 2),
                             "previous_close": previous_close,
+                            "iopv": iopv,
+                            "premium_percent": premium_percent,
                         }
                         logger.debug(f"ETF {code} 数据获取成功（腾讯）：price={price}, change={change_percent}%")
                         self._cache.set(cache_key, result, ttl)
@@ -2279,7 +2293,51 @@ class ETFPriceAPI:
         except Exception as e:
             logger.debug(f"Tencent ETF API error for {code}: {e}")
 
-        # ===== 数据源 2: 新浪财经 API =====
+        # ===== 数据源 2: 东方财富 Push API =====
+        try:
+            # 修复 secid 构造逻辑：
+            # 1xxxxx = 上交所证券 (510xxx, 511xxx, 512xxx, 513xxx, 515xxx, 516xxx, 517xxx, 518xxx, 50xxxx)
+            # 0xxxxx = 深交所证券 (15xxxx, 16xxxx, 18xxxx)
+            if code.startswith("51") or code.startswith("50"):
+                secid = f"1.{code}"
+            elif code.startswith("15") or code.startswith("16") or code.startswith("18"):
+                secid = f"0.{code}"
+            else:
+                # 默认尝试上交所格式，失败时会自动尝试深交所
+                secid = f"1.{code}"
+
+            url = "https://push2.eastmoney.com/api/qt/stock/get"
+            # fltt=2 时 f43 直接返回小数价格；f170=涨跌幅(%)，f169=涨跌额
+            params = {"secid": secid, "fields": "f43,f44,f45,f46,f47,f48,f49,f14,f169,f170", "fltt": "2", "invt": "2"}
+
+            content = await self._request_with_retry("GET", url, params=params, timeout=aiohttp.ClientTimeout(total=5.0))
+            if content:
+                data = json.loads(content)
+                if data.get("data"):
+                    tick = data["data"]
+                    price = float(tick.get("f43", 0))
+                    change_percent = float(tick.get("f170", 0))  # f170 = 涨跌幅(%)
+                    change = float(tick.get("f169", 0))          # f169 = 涨跌额
+                    previous_close = float(tick.get("f46", 0)) if tick.get("f46") else price - change
+
+                    result = {
+                        "code": code,
+                        "name": tick.get("f14", code),
+                        "price": price,
+                        "change": change,
+                        "change_percent": change_percent,
+                        "volume": float(tick.get("f47", 0)),
+                        "previous_close": previous_close,
+                        "iopv": None,
+                        "premium_percent": None,
+                    }
+                    logger.debug(f"ETF {code} 数据获取成功（东方财富）：price={price}, change={change_percent}%")
+                    self._cache.set(cache_key, result, ttl)
+                    return result
+        except Exception as e:
+            logger.debug(f"EastMoney ETF API error for {code}: {e}")
+
+        # ===== 数据源 3: 新浪财经 API =====
         try:
             exchange = 'sh' if code.startswith('51') or code.startswith('50') else 'sz'
             url = f"https://hq.sinajs.cn/list={exchange}{code}"
@@ -2302,95 +2360,14 @@ class ETFPriceAPI:
                             "change": change,
                             "change_percent": round(change_percent, 2),
                             "previous_close": previous_close,
+                            "iopv": None,
+                            "premium_percent": None,
                         }
                         logger.debug(f"ETF {code} 数据获取成功（新浪）：price={price}, change={change_percent}%")
                         self._cache.set(cache_key, result, ttl)
                         return result
         except Exception as e:
             logger.debug(f"Sina ETF API error for {code}: {e}")
-
-        # ===== 数据源 3: 东方财富 Push API (备用) =====
-        try:
-            # 修复 secid 构造逻辑：
-            # 1xxxxx = 上交所证券 (510xxx, 511xxx, 512xxx, 513xxx, 515xxx, 516xxx, 517xxx, 518xxx, 50xxxx)
-            # 0xxxxx = 深交所证券 (15xxxx, 16xxxx, 18xxxx)
-            if code.startswith("51") or code.startswith("50"):
-                secid = f"1.{code}"
-            elif code.startswith("15") or code.startswith("16") or code.startswith("18"):
-                secid = f"0.{code}"
-            else:
-                # 默认尝试上交所格式，失败时会自动尝试深交所
-                secid = f"1.{code}"
-
-            url = "https://push2.eastmoney.com/api/qt/stock/get"
-            params = {"secid": secid, "fields": "f43,f44,f45,f46,f47,f48,f49,f14,f169,f170"}
-
-            content = await self._request_with_retry("GET", url, params=params, timeout=aiohttp.ClientTimeout(total=5.0))
-            if content:
-                data = json.loads(content)
-                if data.get("data"):
-                    tick = data["data"]
-                    price = float(tick.get("f43", 0)) / 100
-                    # f44 是涨跌幅，直接使用更准确
-                    change_percent = float(tick.get("f44", 0))  # 东方财富直接返回百分比
-                    previous_close = float(tick.get("f45", 0)) / 100 if tick.get("f45") else float(tick.get("f46", 0)) / 100
-
-                    result = {
-                        "code": code,
-                        "name": tick.get("f14", code),
-                        "price": price,
-                        "change": price * change_percent / 100 if change_percent else 0,
-                        "change_percent": change_percent,
-                        "volume": float(tick.get("f47", 0)),
-                        "previous_close": previous_close,
-                    }
-                    logger.debug(f"ETF {code} 数据获取成功（东方财富）：price={price}, change={change_percent}%")
-                    self._cache.set(cache_key, result, ttl)
-                    return result
-        except Exception as e:
-            logger.debug(f"EastMoney ETF API error for {code}: {e}")
-
-        # ===== 数据源 3: 腾讯财经 API =====
-        try:
-            # 腾讯财经 API 格式：prefix + code
-            prefix = "sh" if code.startswith('51') or code.startswith('50') else "sz"
-            url = f"https://qt.gtimg.cn/q={prefix}{code}"
-            content = await self._request_with_retry("GET", url)
-            if content:
-                # 解析腾讯格式：v_sh510880="1~名称~代码~price~previous_close~open~high~low..."
-                # 完整格式参考：https://qt.gtimg.cn/q=sh510880
-                match = re.search(r'"([^"]+)"', content)
-                if match:
-                    parts = match.group(1).split("~")
-                    if len(parts) >= 5:
-                        # 腾讯格式详解：
-                        # 0: 未知标识
-                        # 1: 名称
-                        # 2: 代码
-                        # 3: 当前价
-                        # 4: 昨收价
-                        # 5: 开盘价
-                        # ...
-                        # 33: 涨跌幅 (带% 符号)
-                        name = parts[1] if len(parts) > 1 else code
-                        price = float(parts[3]) if len(parts) > 3 and parts[3] else 0
-                        previous_close = float(parts[4]) if len(parts) > 4 and parts[4] else 0
-                        change = price - previous_close
-                        change_percent = (change / previous_close * 100) if previous_close else 0
-
-                        result = {
-                            "code": code,
-                            "name": name,
-                            "price": price,
-                            "change": change,
-                            "change_percent": change_percent,
-                            "previous_close": previous_close,
-                        }
-                        logger.debug(f"ETF {code} 数据获取成功（腾讯财经）：price={price}, change={change_percent}%")
-                        self._cache.set(cache_key, result, ttl)
-                        return result
-        except Exception as e:
-            logger.debug(f"Tencent ETF API error for {code}: {e}")
 
         # ===== 数据源 4: AkShare 基金 ETF 实时行情 =====
         # 注意：AkShare 可能需要较长时间加载，作为最后的备用方案
@@ -2408,6 +2385,8 @@ class ETFPriceAPI:
                             'change_percent': float(row.get('涨跌幅', 0)),
                             'previous_close': float(row.get('昨收', 0)) if '昨收' in row else float(row.get('昨收价', 0)),
                             'name': row.get('名称', code),
+                            'iopv': row.get('IOPV实时估值'),
+                            'premium_percent': float(row.get('基金折价率', 0)) if row.get('基金折价率') not in (None, '-') else None,
                         }
                 return None
 
@@ -2426,6 +2405,8 @@ class ETFPriceAPI:
                     "change": result['price'] * result['change_percent'] / 100 if result['change_percent'] else 0,
                     "change_percent": result['change_percent'],
                     "previous_close": result['previous_close'],
+                    "iopv": result.get('iopv'),
+                    "premium_percent": result.get('premium_percent'),
                 }
                 self._cache.set(cache_key, result_data, ttl)
                 return result_data

--- a/backend/models.py
+++ b/backend/models.py
@@ -79,6 +79,9 @@ class ValuationResult(BaseModel):
     valuation_signal: Optional[str] = Field(None, description="定投信号：深度低估/低估/合理/偏高/高估")
     signal_action: Optional[str] = Field(None, description="建议操作：加倍定投/正常定投/持有/止盈/卖出")
     signal_source: Optional[str] = Field(None, description="信号数据来源：PE分位/债券收益率/价格分位/黄金价格")
+    # 场内折溢价
+    iopv: Optional[float] = Field(None, description="场内ETF IOPV 实时估值")
+    premium_percent: Optional[float] = Field(None, description="场内ETF折溢价率(%，正=溢价)")
 
 
 class MarketData(BaseModel):

--- a/frontend/src/fundManagerUI.ts
+++ b/frontend/src/fundManagerUI.ts
@@ -3,6 +3,7 @@ import { api } from './api';
 import { toast } from './toast';
 import { StorageService } from './storage';
 import type { Fund } from './types';
+import * as echarts from 'echarts';
 
 class FundManagerUI {
   private container: HTMLElement | null = null;
@@ -131,6 +132,7 @@ class FundManagerUI {
                   <tr>
                     <th>基金代码</th>
                     <th>基金名称</th>
+                    <th>市场</th>
                     <th>基金类型</th>
                     <th>持有份额</th>
                     <th>最新净值<span class="nav-date" style="font-weight: normal; margin-left: 4px;">(日期)</span></th>
@@ -144,6 +146,7 @@ class FundManagerUI {
                       </span>
                     </th>
                     <th>估值方法</th>
+                    <th>折溢价</th>
                     <th class="sortable-header" id="sort-pe-percentile" style="cursor: pointer; user-select: none;">
                       估值分位
                       <span class="sort-icons">
@@ -194,10 +197,28 @@ class FundManagerUI {
       ? `${fund.index_name || '指数'} 当前 PE ${fund.pe_value != null ? fund.pe_value.toFixed(2) : '--'}，历史分位 ${fund.pe_percentile.toFixed(1)}%`
       : this.getPercentileNaTitle(fund);
 
+    // 市场类型（场内/场外）
+    const marketType = this.getMarketType(fund);
+    const marketBadge = marketType === 'on_exchange'
+      ? `<span class="badge badge-info">场内</span>`
+      : marketType === 'off_exchange'
+        ? `<span class="badge badge-secondary">场外</span>`
+        : `<span class="badge badge-secondary">未知</span>`;
+
+    // 场内折溢价
+    const premiumDisplay = fund.premium_percent != null
+      ? (fund.premium_percent > 0.5
+          ? `<span class="premium-tag premium-positive" title="市价高于净值，溢价买入需谨慎">${fund.premium_percent.toFixed(2)}% 溢价</span>`
+          : fund.premium_percent < -0.5
+            ? `<span class="premium-tag premium-negative" title="市价低于净值，折价买入更划算">${fund.premium_percent.toFixed(2)}% 折价</span>`
+            : `<span class="premium-tag premium-flat" title="市价与净值接近">${fund.premium_percent.toFixed(2)}%</span>`)
+      : (marketType === 'on_exchange' ? '<span style="opacity:0.4">--</span>' : '<span style="opacity:0.3">-</span>');
+
     return `
       <tr class="fade-in" data-fund-code="${fund.fund_code}">
         <td><strong>${fund.fund_code}</strong></td>
         <td>${fund.fund_name}</td>
+        <td>${marketBadge}</td>
         <td><span class="badge badge-secondary">${fund.fund_type}</span></td>
         <td>${this.formatNumber(fund.total_shares)}</td>
         <td>${navDisplay} ${navDateDisplay}</td>
@@ -207,6 +228,7 @@ class FundManagerUI {
           ${changePercentDisplay}
         </td>
         <td><span class="valuation-method-tag">${valuationMethodDisplay}</span></td>
+        <td>${premiumDisplay}</td>
         <td title="${pePercentileTitle}">${pePercentileDisplay}</td>
         <td>${this.renderSignal(fund)}</td>
         <td>
@@ -216,6 +238,25 @@ class FundManagerUI {
         </td>
       </tr>
     `;
+  }
+
+  // 市场类型判定（与后端 determine_market_type 逻辑一致）
+  private getMarketType(fund: Fund): 'on_exchange' | 'off_exchange' | 'unknown' {
+    const code = fund.fund_code || '';
+    const name = fund.fund_name || '';
+    const type = fund.fund_type || '';
+    if (!code) return 'unknown';
+    if (name.includes('联接')) return 'off_exchange';
+    if (/ETF|LOF|封闭式/.test(name)) return 'on_exchange';
+    if (/ETF|LOF|封闭式/.test(type)) return 'on_exchange';
+    const p2 = code.slice(0, 2);
+    if (['15', '16', '18'].includes(p2)) return 'on_exchange';
+    if (p2 === '51') {
+      return ['510', '511', '512', '513', '515', '516', '517', '518'].includes(code.slice(0, 3)) ? 'on_exchange' : 'off_exchange';
+    }
+    if (p2 === '50' || p2 === '52') return 'on_exchange';
+    if (code.startsWith('0')) return 'off_exchange';
+    return 'unknown';
   }
 
   // 定投信号显示
@@ -244,10 +285,18 @@ class FundManagerUI {
       : source === 'pe_csindex' ? '基于中证官网PE分位'
       : source === 'pe_csindex_short' ? '基于短周期PE(仅20日)'
       : '';
+
+    // 场内基金高估 → 加做空提示线（融券门槛高，仅作提示）
+    const isOnExchange = this.getMarketType(fund) === 'on_exchange';
+    const shortHint = (isOnExchange && (signal === '高估' || signal === '偏高'))
+      ? `<span style="font-size: 10px; color: #e74c3c; font-weight: 600;" title="场内基金可融券做空（需两融账户且标的为两融标的）">🛑 可融券做空</span>`
+      : '';
+
     return `
       <div style="display: flex; flex-direction: column; gap: 2px;">
         <span class="badge ${colorClass}" style="font-size: 11px;" title="${sourceLabel}">${signal}</span>
         <span style="font-size: 10px; color: var(--muted-color, #888);">${action}</span>
+        ${shortHint}
       </div>
     `;
   }
@@ -341,14 +390,24 @@ class FundManagerUI {
         if (fundCode) {
           this.handleDeleteFund(fundCode);
         }
+        return; // 删除按钮不触发行点击弹窗
       }
 
       if (target.id === 'sort-change-percent' || target.closest('#sort-change-percent')) {
         this.handleSortChangePercent();
+        return;
       }
 
       if (target.id === 'sort-pe-percentile' || target.closest('#sort-pe-percentile')) {
         this.handleSortPePercentile();
+        return;
+      }
+
+      // 点击基金行 → 弹出基金全量信息
+      const row = target.closest<HTMLElement>('tr[data-fund-code]');
+      if (row) {
+        const fundCode = row.dataset.fundCode;
+        if (fundCode) this.showFundDetail(fundCode);
       }
     });
 
@@ -552,6 +611,11 @@ class FundManagerUI {
                 fund.valuation_signal = result.valuation_signal;
                 fund.signal_action = result.signal_action;
                 fund.signal_source = result.signal_source;
+              }
+              // 更新场内折溢价
+              if (result.premium_percent != null) {
+                fund.premium_percent = result.premium_percent;
+                fund.iopv = result.iopv;
               }
               // 实时更新单个基金行
               this.updateFundRow(result.fund_code);
@@ -767,6 +831,131 @@ class FundManagerUI {
     }
     this.sortColumn = 'pe_percentile';
     this.sortAndRender();
+  }
+
+  // ═══ 基金全量信息弹窗 ═══
+
+  private async showFundDetail(fundCode: string): Promise<void> {
+    const fund = fundManager.getFund(fundCode);
+    if (!fund) return;
+
+    // 创建遮罩和弹窗
+    const overlay = document.createElement('div');
+    overlay.className = 'fund-modal-overlay';
+    overlay.innerHTML = `
+      <div class="fund-modal">
+        <div class="fund-modal-header">
+          <h3>${fund.fund_name} <span style="font-weight:400;font-size:13px;color:var(--text-tertiary);">${fund.fund_code}</span></h3>
+          <button class="fund-modal-close" style="background:none;border:none;font-size:24px;cursor:pointer;color:var(--text-secondary);">&times;</button>
+        </div>
+        <div class="fund-modal-body">
+          <div class="fund-modal-loading">加载中...</div>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+
+    // 绑定关闭
+    const close = () => overlay.remove();
+    overlay.querySelector('.fund-modal-close')?.addEventListener('click', close);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+
+    // 加载数据
+    try {
+      const navRes = await api.getFundNavHistory(fundCode);
+      const navData = navRes?.success && navRes?.data ? navRes.data : [];
+      this.renderFundDetailModal(fund, navData, overlay);
+    } catch (e) {
+      overlay.querySelector('.fund-modal-body')!.innerHTML = '<div style="padding:40px;text-align:center;color:var(--text-tertiary);">加载失败</div>';
+    }
+  }
+
+  private renderFundDetailModal(fund: Fund, navData: any[], overlay: HTMLElement): void {
+    const body = overlay.querySelector('.fund-modal-body')!;
+
+    // 基本信息
+    const isDark = document.body.classList.contains('dark-mode');
+    const signalColor = (s: string) => s === '深度低估' || s === '低估' ? 'var(--success-color)' : s === '高估' ? 'var(--danger-color)' : s === '偏高' ? 'var(--warning-color)' : 'var(--text-secondary)';
+    const marketType = this.getMarketType(fund);
+    const marketLabel = marketType === 'on_exchange' ? '场内' : marketType === 'off_exchange' ? '场外' : '未知';
+
+    body.innerHTML = `
+      <div class="fund-modal-info">
+        <div class="info-grid">
+          <div class="info-item"><span class="label">基金类型</span><span class="value">${fund.fund_type}</span></div>
+          <div class="info-item"><span class="label">市场类型</span><span class="value">${marketLabel}</span></div>
+          <div class="info-item"><span class="label">最新净值</span><span class="value">${fund.nav ? fund.nav.toFixed(4) : '-'}</span></div>
+          <div class="info-item"><span class="label">净值日期</span><span class="value">${fund.nav_date || '-'}</span></div>
+          <div class="info-item"><span class="label">预估涨跌</span><span class="value" style="color:${fund.estimated_change_percent && fund.estimated_change_percent >= 0 ? 'var(--danger-color)' : 'var(--success-color)'}">${fund.estimated_change_percent != null ? (fund.estimated_change_percent >= 0 ? '+' : '') + fund.estimated_change_percent.toFixed(2) + '%' : '-'}</span></div>
+          ${fund.premium_percent != null ? `<div class="info-item"><span class="label">折溢价</span><span class="value" style="color:${fund.premium_percent > 0.5 ? 'var(--danger-color)' : fund.premium_percent < -0.5 ? 'var(--success-color)' : 'var(--text-secondary)'}">${fund.premium_percent.toFixed(2)}%</span></div>` : ''}
+          <div class="info-item"><span class="label">持有份额</span><span class="value">${this.formatNumber(fund.total_shares)}</span></div>
+        </div>
+      </div>
+      <div class="fund-modal-section">
+        <h4>📈 净值走势</h4>
+        <div class="fund-modal-chart"></div>
+      </div>
+      <div class="fund-modal-section">
+        <h4>📊 估值信号</h4>
+        <div class="fund-modal-signals">
+          <div class="info-grid">
+            ${fund.pe_percentile != null ? `
+              <div class="info-item"><span class="label">估值分位</span><span class="value" style="color:${fund.pe_percentile > 70 ? 'var(--danger-color)' : fund.pe_percentile > 50 ? 'var(--warning-color)' : 'var(--success-color)'}">${fund.pe_percentile.toFixed(1)}%</span></div>
+              <div class="info-item"><span class="label">PE</span><span class="value">${fund.pe_value != null ? fund.pe_value.toFixed(2) : '-'}</span></div>
+              <div class="info-item"><span class="label">跟踪指数</span><span class="value">${fund.index_name || '-'}</span></div>
+            ` : ''}
+            ${fund.valuation_signal ? `
+              <div class="info-item"><span class="label">定投信号</span><span class="value" style="font-weight:700;color:${signalColor(fund.valuation_signal)}">${fund.valuation_signal}</span></div>
+              <div class="info-item"><span class="label">建议操作</span><span class="value">${fund.signal_action || '-'}</span></div>
+            ` : ''}
+          </div>
+        </div>
+      </div>`;
+
+    // 渲染净值走势图
+    const chartEl = body.querySelector<HTMLElement>('.fund-modal-chart');
+    if (chartEl && navData.length > 1) {
+      this.renderModalChart(chartEl, navData, isDark, fund.fund_name);
+    } else if (chartEl) {
+      chartEl.innerHTML = '<div style="padding:30px;text-align:center;color:var(--text-tertiary);font-size:13px;">暂无净值数据</div>';
+    }
+  }
+
+  private renderModalChart(chartEl: HTMLElement, navData: any[], isDark: boolean, fundName: string): void {
+    const dates = navData.map((d: any) => (d.date || '').slice(0, 10));
+    const navValues = navData.map((d: any) => d.nav || d.adjusted_nav || 0);
+
+    const chart = echarts.init(chartEl);
+    const axColor = isDark ? '#8494ad' : '#64748b';
+    const axLineColor = isDark ? '#1e2d42' : '#cbd5e1';
+    const gridColor = isDark ? '#152238' : '#e2e8f0';
+    const navColor = isDark ? '#4a90d9' : '#3b82f6';
+    const navAreaColor = isDark ? 'rgba(74,144,217,0.2)' : 'rgba(59,130,246,0.12)';
+
+    chart.setOption({
+      tooltip: { trigger: 'axis', axisPointer: { type: 'cross' } },
+      grid: { left: '3%', right: '4%', bottom: '8%', top: '4%', containLabel: true },
+      xAxis: {
+        type: 'category', data: dates,
+        axisLabel: { rotate: 45, fontSize: 11, color: axColor },
+        axisLine: { lineStyle: { color: axLineColor } },
+        splitLine: { lineStyle: { color: gridColor, type: 'dashed' as const } },
+      },
+      yAxis: {
+        type: 'value', scale: true,
+        axisLabel: { color: axColor },
+        splitLine: { lineStyle: { color: gridColor, type: 'dashed' as const } },
+      },
+      dataZoom: [{ type: 'inside', xAxisIndex: 0 }],
+      series: [{
+        type: 'line', name: fundName,
+        data: navValues, smooth: true,
+        lineStyle: { width: 2, color: navColor },
+        areaStyle: { color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: navAreaColor },
+          { offset: 1, color: isDark ? 'rgba(74,144,217,0)' : 'rgba(59,130,246,0)' },
+        ]) },
+      }],
+    });
   }
 }
 

--- a/frontend/src/fundQuant/panels/Allocation.ts
+++ b/frontend/src/fundQuant/panels/Allocation.ts
@@ -8,7 +8,7 @@ export class Allocation extends PanelBase {
   private chartType: 'pie' | 'treemap' = 'pie'
 
   constructor() {
-    super({ id: 'allocation', title: '组合配置', defaultGridPos: { x: 1, y: 2, w: 1, h: 1 } })
+    super({ id: 'allocation', title: '建议仓位', defaultGridPos: { x: 0, y: 1, w: 2, h: 1 } })
   }
 
   render(): HTMLElement {
@@ -16,10 +16,11 @@ export class Allocation extends PanelBase {
     el.className = 'panel-allocation'
     el.innerHTML = `
       <div class="panel-header">
-        <h3>组合配置</h3>
+        <h3>💰 建议仓位</h3>
         <div class="panel-toolbar">
+          <span style="font-size:11px;color:var(--text-tertiary);">基于组合优化，给出每只基金的建议配置比例</span>
           <button class="btn btn-sm btn-outline alloc-toggle-chart" title="切换图表类型">📊</button>
-          <button class="btn btn-sm btn-outline alloc-optimize">优化</button>
+          <button class="btn btn-sm btn-primary alloc-optimize" style="font-weight:600;">⚡ 一键优化</button>
           <button class="btn btn-sm btn-outline btn-save-layout alloc-save-layout">保存</button>
         </div>
       </div>
@@ -140,12 +141,20 @@ export class Allocation extends PanelBase {
     if (!el) return
     const pool = state.get('fundPool')
     const sorted = Object.entries(weights).sort((a, b) => b[1] - a[1])
+    const total = sorted.reduce((s, [, w]) => s + w, 0)
     el.innerHTML = `<table class="alloc-table">
-      <thead><tr><th>基金</th><th class="text-right">权重</th></tr></thead>
-      <tbody>${sorted.map(([code, w]) => `
-        <tr><td class="alloc-name">${pool.find(f => f.fund_code === code)?.fund_name || code}</td>
-        <td class="text-right alloc-weight">${(w * 100).toFixed(1)}%</td></tr>
-      `).join('')}</tbody></table>`
+      <thead><tr><th>#</th><th>基金</th><th class="text-right">建议权重</th><th class="text-right">仓位建议</th></tr></thead>
+      <tbody>${sorted.map(([code, w], i) => {
+        const fund = pool.find(f => f.fund_code === code)
+        const pct = w * 100
+        const suggestion = pct > 25 ? '重仓' : pct > 10 ? '标准仓' : pct > 3 ? '轻仓' : pct > 0 ? '观察仓' : '清仓'
+        const color = pct > 25 ? 'var(--danger-color)' : pct > 10 ? 'var(--warning-color)' : pct > 0 ? 'var(--success-color)' : 'var(--text-tertiary)'
+        return `<tr><td style="color:var(--text-tertiary);font-size:12px;">${i + 1}</td>
+          <td class="alloc-name"><strong>${fund?.fund_name || code}</strong><span style="font-size:11px;color:var(--text-tertiary);margin-left:4px;">${code}</span></td>
+          <td class="text-right alloc-weight" style="font-weight:700;color:${color};">${pct.toFixed(1)}%</td>
+          <td class="text-right"><span style="color:${color};font-weight:600;">${suggestion}</span></td></tr>`
+      }).join('')}</tbody></table>
+      <div style="text-align:right;font-size:11px;color:var(--text-tertiary);margin-top:6px;">合计仓位 ${(total * 100).toFixed(1)}%（其余为现金/低配）</div>`
   }
 
   async refresh(): Promise<void> {

--- a/frontend/src/fundQuant/panels/DetailPanel.ts
+++ b/frontend/src/fundQuant/panels/DetailPanel.ts
@@ -80,8 +80,8 @@ export class DetailPanel extends PanelBase {
         container.innerHTML = '<span style="color:var(--text-tertiary);font-size:12px;">无信号数据</span>'
         return
       }
-      const dirLabel: Record<string, string> = { buy: '↑买入', sell: '↓卖出', hold: '→持有' }
-      const dirColor: Record<string, string> = { buy: 'var(--danger-color)', sell: 'var(--success-color)', hold: 'var(--text-secondary)' }
+      const dirLabel: Record<string, string> = { buy: '↑买入', sell: '↓卖出', hold: '→持有', short: '🛑做空', close_short: '↩平空' }
+      const dirColor: Record<string, string> = { buy: 'var(--danger-color)', sell: 'var(--success-color)', short: 'var(--warning-color)', hold: 'var(--text-secondary)' }
       container.innerHTML = signals.map(s => `
         <div style="display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid var(--border-light);font-size:12px;">
           <span style="color:${dirColor[s.direction] || 'var(--text-secondary)'};font-weight:600;">${dirLabel[s.direction] || s.direction}</span>

--- a/frontend/src/fundQuant/panels/KPIBar.ts
+++ b/frontend/src/fundQuant/panels/KPIBar.ts
@@ -58,7 +58,7 @@ export class KPIBar extends PanelBase {
     this.popupEl?.remove()
     const overlay = document.createElement('div')
     overlay.className = 'signal-popup-overlay'
-    const dirLabel: Record<string, string> = { buy: '↑买入', sell: '↓卖出', hold: '→持有' }
+    const dirLabel: Record<string, string> = { buy: '↑买入', sell: '↓卖出', hold: '→持有', short: '🛑做空', close_short: '↩平空' }
     overlay.innerHTML = `
       <div class="signal-popup-modal">
         <div class="signal-popup-header">
@@ -69,7 +69,7 @@ export class KPIBar extends PanelBase {
           ${signals.map(s => `
             <div class="signal-popup-row">
               <span style="font-weight:600;">${s.fund_name || s.fund_code}</span>
-              <span style="color:${s.direction === 'buy' ? 'var(--danger-color)' : s.direction === 'sell' ? 'var(--success-color)' : 'var(--text-secondary)'}">${dirLabel[s.direction] || s.direction}</span>
+              <span style="color:${s.direction === 'buy' ? 'var(--danger-color)' : (s.direction === 'sell' || s.direction === 'short') ? 'var(--success-color)' : 'var(--text-secondary)'}">${dirLabel[s.direction] || s.direction}</span>
               <span style="color:var(--text-secondary);font-size:12px;">${s.strategy_name}</span>
               <span style="color:var(--text-tertiary);font-size:11px;">${(s.timestamp || '').slice(5, 16)}</span>
             </div>

--- a/frontend/src/fundQuant/state.ts
+++ b/frontend/src/fundQuant/state.ts
@@ -118,9 +118,9 @@ const DEFAULT_LAYOUT: LayoutConfig = {
   name: '默认布局',
   panels: {
     kpi: { visible: true, order: 0 },
-    nav_chart: { visible: true, order: 1, grid_pos: { x: 0, y: 1, w: 2, h: 1 } },
+    allocation: { visible: true, order: 1, grid_pos: { x: 0, y: 1, w: 2, h: 1 } },
     signal_list: { visible: true, order: 2, grid_pos: { x: 0, y: 2, w: 1, h: 1 } },
-    allocation: { visible: true, order: 3, grid_pos: { x: 1, y: 2, w: 1, h: 1 } },
+    nav_chart: { visible: false, order: 3, grid_pos: { x: 0, y: 1, w: 2, h: 1 } },
     fund_ranking: { visible: false, order: 4, grid_pos: { x: 1, y: 0, w: 1, h: 1 } },
     attribution: { visible: false, order: 5, grid_pos: { x: 0, y: 3, w: 1, h: 1 } },
     monthly_returns: { visible: false, order: 6, grid_pos: { x: 1, y: 3, w: 1, h: 1 } },

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -362,6 +362,41 @@ tr:hover { background: var(--bg-tertiary); }
 .badge-info { background: rgba(59,130,246,.12); color: var(--info-color); }
 .badge-gradient { background: var(--primary-color); color: var(--text-inverse); }
 
+/* ═══ 折溢价标签 ═══ */
+.premium-tag { display: inline-flex; align-items: center; padding: 1px 5px; border-radius: 2px; font-size: 11px; font-weight: 600; }
+.premium-positive { background: rgba(239,68,68,.12); color: var(--danger-color); }
+.premium-negative { background: rgba(34,197,94,.12); color: var(--success-color); }
+.premium-flat { background: rgba(128,128,128,.08); color: var(--text-secondary); }
+
+/* ═══ 基金详情弹窗 ═══ */
+.fund-modal-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: rgba(0,0,0,.5); display: flex; align-items: center; justify-content: center;
+  animation: fadeIn .15s ease;
+}
+.fund-modal {
+  background: var(--bg-primary); border-radius: 8px; max-width: 720px; width: 90%;
+  max-height: 85vh; overflow-y: auto; box-shadow: 0 8px 32px rgba(0,0,0,.3);
+  animation: slideUp .2s ease;
+}
+.fund-modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 20px; border-bottom: 1px solid var(--border-light);
+  position: sticky; top: 0; background: var(--bg-primary); z-index: 1;
+}
+.fund-modal-header h3 { margin: 0; font-size: 16px; }
+.fund-modal-body { padding: 16px 20px; }
+.fund-modal-body .info-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
+.fund-modal-body .info-item { display: flex; flex-direction: column; gap: 2px; }
+.fund-modal-body .info-item .label { font-size: 11px; color: var(--text-tertiary); }
+.fund-modal-body .info-item .value { font-size: 14px; font-weight: 600; color: var(--text-primary); }
+.fund-modal-section { margin-top: 20px; }
+.fund-modal-section h4 { margin: 0 0 10px; font-size: 14px; color: var(--text-primary); }
+.fund-modal-chart { height: 320px; width: 100%; }
+.fund-modal-loading { padding: 40px; text-align: center; color: var(--text-tertiary); }
+
+@keyframes slideUp { from { opacity:0; transform:translateY(20px); } to { opacity:1; transform:translateY(0); } }
+
 /* ═══ 涨跌 ═══ */
 .positive { color: var(--danger-color) !important; font-weight: 600; }
 .negative { color: var(--success-color) !important; font-weight: 600; }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -50,6 +50,9 @@ export interface Fund {
   valuation_signal?: string;  // 深度低估/低估/合理/偏高/高估
   signal_action?: string;  // 加倍定投/正常定投/持有/止盈/卖出
   signal_source?: string;  // 信号数据来源
+  // 场内折溢价
+  iopv?: number;  // 场内ETF IOPV 实时估值
+  premium_percent?: number;  // 场内ETF折溢价率(%，正=溢价)
 }
 
 export interface FundData {
@@ -97,6 +100,9 @@ export interface ValuationResult {
   valuation_signal?: string;  // 深度低估/低估/合理/偏高/高估
   signal_action?: string;  // 加倍定投/正常定投/持有/止盈/卖出
   signal_source?: string;  // 信号数据来源
+  // 场内折溢价
+  iopv?: number;  // 场内ETF IOPV 实时估值
+  premium_percent?: number;  // 场内ETF折溢价率(%，正=溢价)
 }
 
 export interface MarketData {


### PR DESCRIPTION
- Implemented short selling (融券卖出) and covering (买券还券) logic in FundPaperTrader.
- Updated Direction enum to include SHORT and CLOSE_SHORT.
- Modified ValuationDeviationStrategy to allow short signals based on parameters.
- Enhanced FundValuationService to include IOPV and premium percent for ETFs.
- Updated ETFPriceAPI to fetch IOPV and premium percent from Tencent and EastMoney APIs.
- Added premium display in FundManagerUI and adjusted layout for better visibility.
- Enhanced Allocation panel to show suggested weights and positions for funds.
- Updated DetailPanel and KPIBar to display short selling signals.
- Improved CSS styles for premium tags and fund detail modal.
- Updated types to include IOPV and premium percent for funds.