### PR TITLE
feat: 选基 live 走 aurora 适配器、废弃旧基类/旧回测引擎（P3 迁移收尾 + 引擎审计）

### DIFF
--- a/backend/api/fund_quant.py
+++ b/backend/api/fund_quant.py
@@ -747,16 +747,17 @@ def _fund_risk_pipeline(strategy_name: str = ""):
     """构造历史时序安全的基金风控管线。
 
     配置策略本身生成目标权重；通用单基金上限会错误拒绝其合法配置，故只保留
-    组合级回撤、日损失、连续亏损与信号频率约束。
+    组合级回撤、日损失、连续亏损与信号频率约束。选基策略走同一套组合级约束
+    （其目标仓位由 Top-N 等权决定，见 _AuroraSelectionAdapter._max_position_pct），
+    不再附加单基金/集中度/现金层级检查。
     """
     from core import (
         RiskPipeline, MaxDrawdownCheck, DailyLossCheck,
         ConsecutiveLossCheck, SignalFrequencyCheck,
     )
-    from ..fund_quant.adapter import FundDomainAdapter
 
     pipeline = RiskPipeline()
-    if strategy_name.endswith("_aurora") and strategy_name not in {"multi_factor_aurora", "index_selection_aurora", "rating_enhanced_aurora"}:
+    if strategy_name.endswith("_aurora"):
         checks = [
             SignalFrequencyCheck(max_per_day=20),
             MaxDrawdownCheck(drawdown_limit=0.20),
@@ -764,6 +765,7 @@ def _fund_risk_pipeline(strategy_name: str = ""):
             ConsecutiveLossCheck(max_losses=7),
         ]
     else:
+        from ..fund_quant.adapter import FundDomainAdapter
         checks = FundDomainAdapter().get_risk_checks("equity")
     for check in checks:
         pipeline.add(check)

--- a/backend/api/fund_quant.py
+++ b/backend/api/fund_quant.py
@@ -225,28 +225,29 @@ async def selection_screen(req: SelectionRequest):
             partial(strategy.screen, fund_type="index", top_n=req.top_n, params=req.params))
         return {"success": True, "data": result}
 
-    if req.strategy == "rating_enhanced":
-        from ..fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
-        strategy = RatingEnhancedSelection()
+    if req.strategy in {"rating_enhanced", "rating_enhanced_aurora"}:
+        from ..fund_quant.adapter import AuroraRatingEnhancedSelection
+        strategy = AuroraRatingEnhancedSelection()
         result = await asyncio.to_thread(
             partial(strategy.screen, fund_type=req.fund_type, top_n=req.top_n, params=req.params))
         return {"success": True, "data": result}
 
-    from ..fund_quant.strategy.selection.multi_factor import MultiFactorSelection
-    strategy = MultiFactorSelection()
+    # 其余请求名兜底：任何 selection 名（含 aurora 后缀）都统一走 aurora 适配器
+    from ..fund_quant.adapter import AuroraMultiFactorSelection
+    strategy = AuroraMultiFactorSelection()
 
     # 兼容旧值映射
     fund_type = TYPE_COMPAT.get(req.fund_type, req.fund_type)
 
     # 指数基金使用独立的 5 维度评分策略
     if fund_type == "index":
-        from ..fund_quant.strategy.selection.index_selection import IndexSelectionStrategy
-        idx_strategy = IndexSelectionStrategy()
+        from ..fund_quant.adapter import AuroraIndexSelection
+        strategy = AuroraIndexSelection()
         # 注入 ETF 市场数据
         etf_data = await asyncio.to_thread(get_etf_market_data)
         if etf_data:
-            idx_strategy._state["liquidity_data"] = etf_data.get("liquidity", {})
-            idx_strategy._state["premium_vol_data"] = etf_data.get("premium", {})
+            strategy._state["liquidity_data"] = etf_data.get("liquidity", {})
+            strategy._state["premium_vol_data"] = etf_data.get("premium", {})
         # 对每个候选基金计算跟踪误差
         from ..fund_quant.data.storage import get_all_fund_codes, get_nav_history
         tracking = {}
@@ -257,20 +258,21 @@ async def selection_screen(req: SelectionRequest):
             te = await asyncio.to_thread(compute_tracking_errors, code, nav_vals)
             if te is not None:
                 tracking[code] = te
-        idx_strategy._state["tracking_errors"] = tracking
+        strategy._state["tracking_errors"] = tracking
 
         result = await asyncio.to_thread(
-            partial(idx_strategy.screen, fund_type="index", top_n=req.top_n, params=req.params))
+            partial(strategy.screen, fund_type="index", top_n=req.top_n, params=req.params))
         return {"success": True, "data": result}
 
     # 校验请求的 fund_type 是否在策略适用范围内
     # TYPE_COMPAT 会把 "stock"→"equity" 等旧名映射到新名，而 applicable_fund_types
     # 用的是策略原始类型名，两者都校验，避免误判（否则多因子策略永远返回空）
-    if (req.fund_type not in strategy.applicable_fund_types
-            and fund_type not in strategy.applicable_fund_types):
+    scorer = strategy.selection_cls()
+    applicable = getattr(scorer, "applicable_fund_types", []) or []
+    if (req.fund_type not in applicable and fund_type not in applicable):
         # commodity/fof 等无 selection 策略的类型 → 返回空结果而非 400
         return {"success": True, "data": {
-            "strategy": strategy.strategy_name,
+            "strategy": scorer.strategy_name,
             "fund_type": fund_type,
             "top_n": req.top_n,
             "rankings": [],

--- a/backend/api/fund_quant.py
+++ b/backend/api/fund_quant.py
@@ -939,6 +939,17 @@ def _run_backtest_sync(config_dict: dict) -> str:
         pool = strategy._pool_codes() if hasattr(strategy, "_pool_codes") else fund_codes
         for code in pool or fund_codes:
             strategy._meta[code] = get_fund_meta(code) or {}
+        # 指数选基需要跟踪误差等外部 _state：对传入池轻量估算（一次，非逐 bar）
+        if isinstance(strategy, _adapter.AuroraIndexSelection):
+            from ..fund_quant.data.storage import get_nav_histories
+            strategy._state["tracking_errors"] = {}
+            if fund_codes:
+                all_navs = get_nav_histories(fund_codes, start, end)
+                for code, navs in all_navs.items():
+                    vals = [r["nav"] for r in navs if r.get("nav")]
+                    te = compute_tracking_errors(code, vals)
+                    if te is not None:
+                        strategy._state["tracking_errors"][code] = te
 
     execution = T1ExecutionEngine(confirmation_delay=1)
     execution.set_capital(initial_capital)

--- a/backend/api/fund_quant.py
+++ b/backend/api/fund_quant.py
@@ -933,6 +933,12 @@ def _run_backtest_sync(config_dict: dict) -> str:
     custom_params = config_dict.get("params", {})
     strategy = strategy_cls()
     strategy.params.update(custom_params)
+    # 选基策略：预载 meta（回测中禁止在 on_data 内读 storage），nav 由 bar 流提供
+    if hasattr(strategy, "_meta") and hasattr(strategy, "_pool_codes"):
+        from ..fund_quant.data.storage import get_fund_meta
+        pool = strategy._pool_codes() if hasattr(strategy, "_pool_codes") else fund_codes
+        for code in pool or fund_codes:
+            strategy._meta[code] = get_fund_meta(code) or {}
 
     execution = T1ExecutionEngine(confirmation_delay=1)
     execution.set_capital(initial_capital)

--- a/backend/fund_quant/adapter.py
+++ b/backend/fund_quant/adapter.py
@@ -1797,19 +1797,63 @@ class AuroraMaxDiversification(_AuroraAllocationBase):
 
 # ── 多因子与指数选基（AuroraCore 注册入口）──
 
+def _injected_fund_data(section: dict[str, dict], codes: list[str],
+                        date_str: str) -> list[dict]:
+    """按 as-of 日期把截面 meta + nav_values 构造成 scorer.screen(fund_data=...) 输入。
+
+    section 由 adapter 的 self._meta/_hist 累积而来（nav 均来自 bar 流，无 storage 读）；
+    meta 为 None 时给空 dict，让评分器对其中的可选字段中性降级。
+    """
+    out = []
+    for code in codes:
+        meta = (section[code].get("meta") or {}) if code in section else {}
+        nav_values = [n for d, n in (section[code]["hist"] if code in section else []) if d <= date_str]
+        if not nav_values:
+            continue
+        item = {**meta, "fund_code": code, "fund_type": meta.get("fund_type", ""),
+                "nav_values": nav_values}
+        out.append(item)
+    return out
+
+
 class _AuroraSelectionAdapter(Strategy):
-    """选基策略的 Aurora 注册入口；历史回测保持静默以避免无时点截面的全库查询。"""
+    """选基策略的 Aurora 注册入口。
+
+    实时/模拟：on_data 按固定交易日频次（rebalance_days）重算排名，
+    对高分基金 emit 信号（沿用现有行为）。
+    历史回测：从 bar 流累积多基金净值（无前视），到调仓日把截至当日构造的
+    fund_data 截面注入 scorer.screen(fund_data=...) 重算 Top-N 并 emit 调仓信号；
+    不再静默（此前为避开全库未来读取而关停）。_state 注入字段（如指数跟踪误差）
+    由子类 _preload_state() 提供，API 调用方也走同一入口。
+    """
     selection_cls = None
 
     def __init__(self):
         super().__init__()
         self.params = {**self.default_params}
         self._state: dict = {}
+        self._hist: dict[str, list[tuple[str, float]]] = {}  # code -> [(date, nav)]
+        self._meta: dict[str, dict] = {}
+        self._cur_date = ""
+        self._day_count = 0
+        self._last_rebalance_day = 0
+        self._first_rebalance = True
 
-    def screen(self, fund_type="all", top_n=5, params=None):
+    def _preload_state(self, scorer) -> None:
+        """子类可覆写：把 index 等需要的 _state 数据预注入 scorer"""
+
+    def _pool_codes(self) -> list[str]:
+        config_pool = list(self.params.get("fund_pool", {})) if self.params.get("fund_pool") else []
+        seen = list(self._hist.keys())
+        return list(dict.fromkeys(config_pool + seen))
+
+    def screen(self, fund_type="all", top_n=5, params=None, fund_data=None):
         scorer = self.selection_cls()
         self._copy_state_to(scorer)
-        return scorer.screen(fund_type=fund_type, top_n=top_n, params=params)
+        kwargs = dict(fund_type=fund_type, top_n=top_n, params=params)
+        if fund_data is not None:
+            kwargs["fund_data"] = fund_data
+        return scorer.screen(**kwargs)
 
     def score(self, fund_type="all", params=None):
         scorer = self.selection_cls()
@@ -1819,25 +1863,74 @@ class _AuroraSelectionAdapter(Strategy):
     def _copy_state_to(self, scorer):
         scorer._state.update(getattr(self, "_state", {}))
 
-    def on_data(self, data):
-        if self.ctx is None or self.ctx.mode == "backtest":
-            return
+    def _fund_type(self) -> str:
+        return str(self.params.get("fund_type", "all"))
+
+    def _rebalance(self, date_str: str):
+        """按 as-of 截面重算 Top-N 并 emit 调仓信号（多因子/指数/评级回测 + 指数实盘共用）。"""
         scorer = self.selection_cls()
-        result = scorer.screen(
-            fund_type=self.params.get("fund_type", "all"),
-            top_n=int(self.params.get("top_n", 5)),
-            params=self.params,
-        )
-        scores = {row["fund_code"]: float(row["total_score"])
-                  for row in result.get("rankings", [])}
+        self._copy_state_to(scorer)
+        self._preload_state(scorer)
+        fund_type = self._fund_type()
+        pool = [c for c in self._pool_codes() if c in self._hist and self._hist[c]]
+        section = _injected_fund_data({c: {"meta": self._meta.get(c), "hist": self._hist[c]}
+                                       for c in pool}, pool, date_str)
+        if len(section) < 2:
+            return False
+        result = scorer.screen(fund_type=fund_type, top_n=int(self.params.get("top_n", 5)),
+                               fund_data=section)
+        ranked = [r["fund_code"] for r in result.get("rankings", [])]
+        if not ranked:
+            return False
+        top = set(ranked[:int(self.params.get("top_n", 5))])
+        all_codes = [c for c in self._hist.keys() if c]
+        for code in list(all_codes):
+            pos = self.ctx.execution.get_position(code) if self.ctx.execution else None
+            if code not in top and pos is not None and pos.volume > 0:
+                self.ctx.emit(Signal(
+                    id="", strategy=self.name, symbol=code,
+                    direction=Direction.CLOSE_LONG, price=0,
+                    volume=pos.volume, confidence=1.0,
+                    reason=f"{self.name}: 跌出Top-N, 清仓",
+                ))
+        for code in top:
+            pos = self.ctx.execution.get_position(code) if self.ctx.execution else None
+            if pos is not None and pos.volume > 0:
+                continue
+            hist = self._hist.get(code)
+            nav = hist[-1][1] if hist else 0
+            if not nav or nav <= 0:
+                continue
+            weight = min(float(self.params.get("max_single_weight", 1.0)),
+                         1.0 / max(len(top), 1))
+            target_amt = (self.ctx.portfolio_value or 0) * weight
+            self.ctx.emit(Signal(
+                id="", strategy=self.name, symbol=code,
+                direction=Direction.LONG, price=float(nav),
+                volume=target_amt / nav, confidence=1.0,
+                reason=f"{self.name}: 选基Top-N 评分买入",
+            ))
+        return True
+
+    def on_data(self, data):
         code = getattr(data, "fund_code", "") or getattr(data, "symbol", "")
         nav = getattr(data, "nav", getattr(data, "close", 0))
-        if code in scores and nav and nav > 0:
-            self.ctx.emit(Signal(
-                id="", strategy=self.name, symbol=code, direction=Direction.LONG,
-                price=float(nav), volume=1.0, confidence=scores[code],
-                reason=f"选基评分={scores[code]:.4f}",
-            ))
+        date_str = str(getattr(data, "date", ""))
+        if not code or not nav or nav <= 0:
+            return
+        self._hist.setdefault(code, []).append((date_str, nav))
+        # meta 只经调用方预载（API/回测 runner 在 run 前 set _meta），此处永不读 storage
+        self._meta.setdefault(code, {})
+
+        # 历史回测与实时共用同一截面重放：新交易日计数，每 rebalance_days 调仓日
+        # 用截至当日的基金截面（nav 全来自 bar 流）重算 Top-N 并 emit。
+        if date_str != self._cur_date:
+            self._cur_date = date_str
+            self._day_count += 1
+            freq = max(int(self.params.get("rebalance_days", 20)), 1)
+            if (self._day_count - self._last_rebalance_day) >= freq:
+                if self._rebalance(date_str):
+                    self._last_rebalance_day = self._day_count
 
 
 @StrategyRegistry.register("multi_factor_aurora")
@@ -1845,7 +1938,7 @@ class AuroraMultiFactorSelection(_AuroraSelectionAdapter):
     name = "multi_factor_aurora"
     strategy_type = "selection"
     description = "多因子选基: AuroraCore 统一注册入口"
-    default_params = {"fund_type": "all", "top_n": 5}
+    default_params = {"fund_type": "all", "top_n": 5, "rebalance_days": 20}
 
     @property
     def selection_cls(self):
@@ -1858,76 +1951,45 @@ class AuroraIndexSelection(_AuroraSelectionAdapter):
     name = "index_selection_aurora"
     strategy_type = "selection"
     description = "指数基金五维评分: AuroraCore 统一注册入口"
-    default_params = {"fund_type": "index", "top_n": 5}
+    default_params = {"fund_type": "index", "top_n": 5, "rebalance_days": 20}
 
     @property
     def selection_cls(self):
         from .strategy.selection.index_selection import IndexSelectionStrategy
         return IndexSelectionStrategy
 
+    def _preload_state(self, scorer) -> None:
+        """指数五维评分需要跟踪误差/流动性/折溢价；仅用调用方已注入的 self._state。"""
+        for key in ("tracking_errors", "liquidity_data", "premium_vol_data"):
+            val = self._state.get(key)
+            if val:
+                scorer._state[key] = val
+
 
 
 @StrategyRegistry.register("rating_enhanced_aurora")
-class AuroraRatingEnhancedSelection(Strategy):
+class AuroraRatingEnhancedSelection(_AuroraSelectionAdapter):
     """评级增强选基的 AuroraCore 信号入口。
 
-    复用既有截面评分器，仅在实盘/模拟模式按固定频率刷新排名；历史回测不调用
-    无日期截点的存储层查询，避免引入前视偏差。
+    与 multi_factor/index_selection 共用同一 hist as-of 重放骨架：从 bar 流累积
+    多基金净值（无 storage 读、无前视），每 rebalance_days 个交易日把截至当日
+    构造的 fund_data 截面注入评级增强评分器重算 Top-N 并 emit 调仓信号。
+    实时/模拟模式行为一致，只在分数可用时对高分持仓方向发出信号。
     """
     name = "rating_enhanced_aurora"
     strategy_type = "selection"
-    description = "评级增强选基: 按固定频率将截面评分转换为 AuroraCore 信号"
+    description = "评级增强选基: 固定频率截面评分 → AuroraCore 调仓信号"
     default_params = {
         "fund_type": "all",
         "top_n": 5,
-        "evaluation_days": 20,
+        "rebalance_days": 20,
         "score_threshold": 0.5,
     }
 
-    def __init__(self):
-        super().__init__()
-        self.params = {**self.default_params}
-        self._current_date = ""
-        self._day_count = 0
-        self._scores: dict[str, float] = {}
-
-    def on_data(self, data):
-        if self.ctx is None or self.ctx.mode == "backtest":
-            return
-        code = getattr(data, "fund_code", "") or getattr(data, "symbol", "")
-        nav = getattr(data, "nav", getattr(data, "close", 0))
-        date_str = str(getattr(data, "date", ""))
-        if not code or not nav or nav <= 0:
-            return
-
-        if date_str != self._current_date:
-            self._current_date = date_str
-            self._day_count += 1
-            if (self._day_count - 1) % max(int(self.params["evaluation_days"]), 1) == 0:
-                self._refresh_scores()
-
-        score = self._scores.get(code)
-        if score is None:
-            return
-        direction = Direction.LONG if score >= float(self.params["score_threshold"]) else Direction.HOLD
-        self.ctx.emit(Signal(
-            id="", strategy=self.name, symbol=code, direction=direction,
-            price=float(nav), volume=1.0, confidence=score,
-            reason=f"评级增强评分={score:.4f}",
-        ))
-
-    def _refresh_scores(self):
+    @property
+    def selection_cls(self):
         from .strategy.selection.rating_enhanced import RatingEnhancedSelection
-
-        scorer = RatingEnhancedSelection()
-        result = scorer.screen(
-            fund_type=self.params["fund_type"],
-            top_n=int(self.params["top_n"]),
-        )
-        self._scores = {
-            row["fund_code"]: float(row["total_score"])
-            for row in result.get("rankings", [])
-        }
+        return RatingEnhancedSelection
 
 class FundCostModelAdapter(CostModel):
     """Adapt FundCostModel to core.CostModel interface — 薄适配层，逻辑复用 backtest.cost_model"""

--- a/backend/fund_quant/adapter.py
+++ b/backend/fund_quant/adapter.py
@@ -1798,11 +1798,14 @@ class AuroraMaxDiversification(_AuroraAllocationBase):
 # ── 多因子与指数选基（AuroraCore 注册入口）──
 
 def _injected_fund_data(section: dict[str, dict], codes: list[str],
-                        date_str: str) -> list[dict]:
+                        date_str: str, scope_fund_type: str | None = None) -> list[dict]:
     """按 as-of 日期把截面 meta + nav_values 构造成 scorer.screen(fund_data=...) 输入。
 
     section 由 adapter 的 self._meta/_hist 累积而来（nav 均来自 bar 流，无 storage 读）；
     meta 为 None 时给空 dict，让评分器对其中的可选字段中性降级。
+    scope_fund_type: 选基池的筛选范围。池子本身是调用方交付的候选集，meta 的 fund_type
+        可能是 None/归一化前的旧值，不该再按单只 meta 的类型把池内成员筛掉；统一打上
+        scope 标签（"all" 表示全品类），让评分器注入路径的 fund_type 过滤放行池内全部成员。
     """
     out = []
     for code in codes:
@@ -1810,7 +1813,8 @@ def _injected_fund_data(section: dict[str, dict], codes: list[str],
         nav_values = [n for d, n in (section[code]["hist"] if code in section else []) if d <= date_str]
         if not nav_values:
             continue
-        item = {**meta, "fund_code": code, "fund_type": meta.get("fund_type", ""),
+        item = {**meta, "fund_code": code,
+                "fund_type": scope_fund_type if scope_fund_type is not None else meta.get("fund_type", ""),
                 "nav_values": nav_values}
         out.append(item)
     return out
@@ -1838,6 +1842,17 @@ class _AuroraSelectionAdapter(Strategy):
         self._day_count = 0
         self._last_rebalance_day = 0
         self._first_rebalance = True
+
+    @staticmethod
+    def _trade_pct(n_picks: int, params: dict) -> float:
+        """单票调仓仓位：选基在当选池内等权（1/n_picks），受 max_single_weight 截断。
+
+        n_picks 是实际当选的 Top-N 成员数（可 < top_n，如池内不足）。等权保证当选
+        成员的盘中金额之和 ≈ 组合权益：依次成交时每单都有现金可扣（T1 引擎按剩余
+        资金截断），末位基金不再出现“整单资金不足被拒”。"""
+        n = max(int(n_picks), 1)
+        cap = float(params.get("max_single_weight", 1.0))
+        return min(1.0 / n, cap)
 
     def _preload_state(self, scorer) -> None:
         """子类可覆写：把 index 等需要的 _state 数据预注入 scorer"""
@@ -1867,14 +1882,23 @@ class _AuroraSelectionAdapter(Strategy):
         return str(self.params.get("fund_type", "all"))
 
     def _rebalance(self, date_str: str):
-        """按 as-of 截面重算 Top-N 并 emit 调仓信号（多因子/指数/评级回测 + 指数实盘共用）。"""
+        """按 as-of 截面重算 Top-N 并 reconcile 到等权目标（多因子/指数/评级共用）。
+
+        - 排名完全来自 bar 流累积的 hist（无 storage 读、无前视）；
+        - meta 的 fund_type 只决定部分评分器输入，不再反向剔除池内候选；
+        - 目标权重 = 当选集合等权（1/|Top-N|，受 max_single_weight 截断），
+          reconcile：超配的卖出释放现金，低配/未持有的买入——与配置类 Aurora
+          适配器同一语义，避免 T+1 引擎“先到的大单占满现金、其余同组挂单被拒”。
+        """
         scorer = self.selection_cls()
         self._copy_state_to(scorer)
         self._preload_state(scorer)
         fund_type = self._fund_type()
         pool = [c for c in self._pool_codes() if c in self._hist and self._hist[c]]
+        scope = "all" if fund_type == "all" else fund_type
         section = _injected_fund_data({c: {"meta": self._meta.get(c), "hist": self._hist[c]}
-                                       for c in pool}, pool, date_str)
+                                       for c in pool}, pool, date_str,
+                                      scope_fund_type=scope)
         if len(section) < 2:
             return False
         result = scorer.screen(fund_type=fund_type, top_n=int(self.params.get("top_n", 5)),
@@ -1882,34 +1906,38 @@ class _AuroraSelectionAdapter(Strategy):
         ranked = [r["fund_code"] for r in result.get("rankings", [])]
         if not ranked:
             return False
-        top = set(ranked[:int(self.params.get("top_n", 5))])
-        all_codes = [c for c in self._hist.keys() if c]
-        for code in list(all_codes):
-            pos = self.ctx.execution.get_position(code) if self.ctx.execution else None
-            if code not in top and pos is not None and pos.volume > 0:
-                self.ctx.emit(Signal(
-                    id="", strategy=self.name, symbol=code,
-                    direction=Direction.CLOSE_LONG, price=0,
-                    volume=pos.volume, confidence=1.0,
-                    reason=f"{self.name}: 跌出Top-N, 清仓",
-                ))
-        for code in top:
-            pos = self.ctx.execution.get_position(code) if self.ctx.execution else None
-            if pos is not None and pos.volume > 0:
-                continue
-            hist = self._hist.get(code)
-            nav = hist[-1][1] if hist else 0
+        top = ranked[:int(self.params.get("top_n", 5))]
+        top_set = set(top)
+        pct = self._trade_pct(len(top_set), self.params)
+        pv = self.ctx.portfolio_value or 0
+        threshold = float(self.params.get("rebalance_threshold", 0.0)) * pv
+        nav_by_code = {c: hist[-1][1] for c, hist in self._hist.items() if hist}
+        for code in list(nav_by_code):
+            nav = nav_by_code[code]
             if not nav or nav <= 0:
                 continue
-            weight = min(float(self.params.get("max_single_weight", 1.0)),
-                         1.0 / max(len(top), 1))
-            target_amt = (self.ctx.portfolio_value or 0) * weight
-            self.ctx.emit(Signal(
-                id="", strategy=self.name, symbol=code,
-                direction=Direction.LONG, price=float(nav),
-                volume=target_amt / nav, confidence=1.0,
-                reason=f"{self.name}: 选基Top-N 评分买入",
-            ))
+            pos = self.ctx.execution.get_position(code) if self.ctx.execution else None
+            current_amt = pos.volume * nav if pos and pos.volume > 0 else 0
+            target_amt = pv * pct if code in top_set else 0.0
+            diff = target_amt - current_amt
+            if abs(diff) < threshold:
+                continue
+            if diff > 0:
+                self.ctx.emit(Signal(
+                    id="", strategy=self.name, symbol=code,
+                    direction=Direction.LONG, price=float(nav),
+                    volume=diff / nav, confidence=1.0,
+                    reason=f"{self.name}: 选基Top-N 等权加仓({pct:.1%})",
+                ))
+            else:
+                sell_vol = min(-diff / nav, pos.volume if pos else 0)
+                if sell_vol > 0:
+                    self.ctx.emit(Signal(
+                        id="", strategy=self.name, symbol=code,
+                        direction=Direction.CLOSE_LONG, price=float(nav),
+                        volume=sell_vol, confidence=1.0,
+                        reason=f"{self.name}: 跌出/超配Top-N, 减至{pct:.1%}",
+                    ))
         return True
 
     def on_data(self, data):

--- a/backend/fund_quant/adapter.py
+++ b/backend/fund_quant/adapter.py
@@ -1062,12 +1062,10 @@ class AuroraBlQuadrant(Strategy):
         if len(valid_codes) < 2:
             return
 
-        # 调用 BlackLittermanQuadrant 计算权重（nav_series 避免 DB 前视）
-        strategy = BlackLittermanQuadrant(params=dict(self.params))
-        result = strategy.optimize(fund_codes=valid_codes, nav_series=nav_series)
-        weights = result.get("weights", {})
-        if not weights:
-            return
+        # BL 四象限权重 — 复用本类已内联的 legacy optimize nav_series 等价路径
+        # （_compute_weights 与 legacy BlackLittermanQuadrant.optimize(nav_series=...) 逐位一致，
+        #   见 test_bl_aurora_equivalence；不引 legacy 类名，OOS 曾在此 NameError 全窗口 failed）。
+        weights = self._compute_weights(nav_series, valid_codes)
 
         # 总权益
         pv = self.ctx.portfolio_value or 0
@@ -1531,15 +1529,21 @@ class AuroraTrendFollowing(_AuroraAllocationBase):
     default_params = {
         "rebalance_freq": "monthly",
         "rebalance_threshold": 0.05,
-        "lookback_days": 200,
+        "lookback_days": 60,
         "buy_threshold": 0.0,
-        "min_history_days": 200,
+        "min_history_days": 60,
     }
-    min_history_days = 200
+    min_history_days = 60
 
     def _compute_weights(self, nav_series, codes):
-        """对每只基金独立计算窗口收益；不满足阈值的基金权重为0。"""
-        lookback = int(self.params.get("lookback_days", 200))
+        """对每只基金独立计算窗口收益；不满足阈值的基金权重为0。
+
+        窗口统一为 60 天（= min_history_days / first-rebalance 门槛）：
+        此前 lookback=200 使建仓要求 200+ 点净值，而首次调仓仅需 20 点就触发，
+        首个再平衡日所有基金都 < 200 点 → active 恒空 → 持仓永远为空。
+        回测起点距数据起点不足 200 点的窗口（本 OOS 全部 11 窗）交易数为 0 即源于此。
+        """
+        lookback = int(self.params.get("lookback_days", 60))
         threshold = float(self.params.get("buy_threshold", 0.0))
         active = {}
         for code in codes:

--- a/backend/fund_quant/backtest/engine.py
+++ b/backend/fund_quant/backtest/engine.py
@@ -1,4 +1,9 @@
-"""FundQuant 事件驱动回测引擎 — 完整 T+1 申赎模拟 + 前视偏差防护"""
+"""FundQuant 事件驱动回测引擎 — ⚠️ 已废弃，仅保留供旧测试引用
+
+历史回测全部走统一引擎 `core.backtest.BacktestEngine`（见 backend/api/fund_quant.py
+`_run_backtest_sync` / `_legacy_backtest_metrics`）。本文件是迁移前的事件驱动实现，
+保留 T+1 申赎模拟 + 前视偏差防护的参考语义；不再被任何生产路径调用。
+"""
 from __future__ import annotations
 
 from datetime import datetime, date, timedelta

--- a/backend/fund_quant/backtest/vectorized_engine.py
+++ b/backend/fund_quant/backtest/vectorized_engine.py
@@ -2,6 +2,9 @@
 
 Full numpy-vectorized computation — no for-loops over trading days.
 Supports any strategy expressible as a weight function f(nav_matrix) -> weight_matrix.
+
+⚠️ 工具端点（非策略回测引擎）：仅 `/backtest/run-vectorized` 的"等权基准对比行"使用；
+无事件循环、无 T+1 结算、无费率/风控。策略回测一律走 core.BacktestEngine（统一引擎）。
 """
 
 from __future__ import annotations

--- a/backend/fund_quant/strategy/selection/multi_factor.py
+++ b/backend/fund_quant/strategy/selection/multi_factor.py
@@ -143,10 +143,11 @@ class MultiFactorSelection(FundStrategyBase):
 
         rankings = []
         for i, fs in enumerate(fund_scores[:top_n]):
+            meta_name = fs["meta"].get("fund_name") if fs["meta"] else ""
             rankings.append({
                 "rank": i + 1,
                 "fund_code": fs["fund_code"],
-                "fund_name": fs.get("fund_name") or (fs["meta"]["fund_name"] if fs["meta"] else ""),
+                "fund_name": fs.get("fund_name") or meta_name,
                 "total_score": round(fs["total_score"], 4),
                 "factors": fs["factors"],
             })
@@ -408,7 +409,7 @@ class MultiFactorSelection(FundStrategyBase):
         rankings = [{
             "rank": i + 1,
             "fund_code": fs["fund_code"],
-            "fund_name": fs.get("fund_name") or (fs["meta"]["fund_name"] if fs["meta"] else ""),
+            "fund_name": fs.get("fund_name") or (fs["meta"].get("fund_name") if fs["meta"] else ""),
             "total_score": round(fs["total_score"], 4),
             "factors": fs["factors"],
         } for i, fs in enumerate(fund_scores[:top_n])]

--- a/tests/fund_quant/test_aurora_selection_adapters.py
+++ b/tests/fund_quant/test_aurora_selection_adapters.py
@@ -70,31 +70,35 @@ class TestAuroraIndexSelectionAdapter:
 
 
 class TestAuroraRatingEnhancedSelectionRefresh:
-    def test_refresh_uses_injected_screen(self, monkeypatch):
-        """_refresh_scores 走 screen → 注入目标分数集。"""
-        from backend.fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
-
-        monkeypatch.setattr(
-            RatingEnhancedSelection,
-            "screen",
-            lambda *a, **k: {"rankings": [{"fund_code": "000001", "total_score": 0.8}]},
+    def test_rating_adapter_uses_rating_scorer(self):
+        """评级增强 Aurora 适配器与 multi/index 共用统一 hist as-of 重放骨架。"""
+        from backend.fund_quant.adapter import (
+            _AuroraSelectionAdapter, AuroraRatingEnhancedSelection,
         )
-        strategy = AuroraRatingEnhancedSelection()
-        strategy._refresh_scores()
-        assert strategy._scores == {"000001": 0.8}
+        assert issubclass(AuroraRatingEnhancedSelection, _AuroraSelectionAdapter)
+        # 统一骨架默认参数：fund_type/top_n/rebalance_days
+        assert AuroraRatingEnhancedSelection.default_params["rebalance_days"] == 20
+        from backend.fund_quant.strategy.selection.rating_enhanced import (
+            RatingEnhancedSelection,
+        )
+        assert AuroraRatingEnhancedSelection().selection_cls is RatingEnhancedSelection
 
-    def test_default_uses_rating_enhanced_scorer(self, monkeypatch):
-        """默认 fund_type=all 走评级增强评分器（非 MultiFactor）。"""
+    def test_screen_forwards_fund_data_to_rating_scorer(self, monkeypatch):
+        """screen(fund_data=...) 转发到评级增强评分器注入路径（不回退 storage）。"""
         from backend.fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
 
         captured = {}
 
-        def fake_screen(self_, fund_type="all", top_n=10):
+        def fake_screen(self_, fund_type="all", top_n=10, params=None, fund_data=None):
             captured["fund_type"] = fund_type
-            return {"rankings": []}
+            captured["fund_data"] = fund_data
+            return {"rankings": [{"fund_code": "000001", "total_score": 0.8}]}
 
         monkeypatch.setattr(RatingEnhancedSelection, "screen", fake_screen)
         strategy = AuroraRatingEnhancedSelection()
-        strategy._refresh_scores()
+        section = [{"fund_code": "000001", "fund_type": "stock",
+                    "nav_values": [1.0] * 80}]
+        result = strategy.screen(fund_type="all", top_n=5, fund_data=section)
+        assert result["rankings"][0]["fund_code"] == "000001"
+        assert captured["fund_data"] is section
         assert captured["fund_type"] == "all"
-        assert strategy._scores == {}

--- a/tests/fund_quant/test_selection_aurora_replay.py
+++ b/tests/fund_quant/test_selection_aurora_replay.py
@@ -13,9 +13,15 @@ from core import BacktestEngine, BacktestConfig, FundNavPoint, T1ExecutionEngine
 from core.strategy import StrategyRegistry
 
 import backend.fund_quant.adapter as _adapter  # noqa: F401 注册适配器
+from backend.api.fund_quant import _fund_risk_pipeline
 from backend.fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
 from backend.fund_quant.strategy.selection.multi_factor import MultiFactorSelection
 from backend.fund_quant.strategy.selection.index_selection import IndexSelectionStrategy
+
+
+def _trade_pct(n_picks, strategy):
+    """取适配器当选池内单票目标仓位（min(1/n_picks, max_single_weight)）。"""
+    return _adapter._AuroraSelectionAdapter._trade_pct(n_picks, strategy.params)
 
 
 def _daily_nav_series(codes, days=120, base=1.0, trend=0.001, spread=0.05,
@@ -43,7 +49,10 @@ def _points(series, start_year=2024):
 
 
 def _run(strategy, points, initial_capital=100000.0):
-    strategy.params.update({"rebalance_days": 10, "top_n": 1})
+    """跑一次 Aurora 回测。不再强制覆盖 params：测试需特定 top_n/rebalance_days 时
+    在调用前自行 strategy.params.update()（避免 _run 把测试设值冲掉）。"""
+    strategy.params.setdefault("rebalance_days", 10)
+    strategy.params.setdefault("top_n", 1)
     # 只在测试未预置 meta 时给默认（保留 index 测试预载的 fund_type/index 字段）
     if not strategy._meta:
         strategy._meta = {c: {"fund_code": c, "fund_name": f"Fund{c}", "fund_type": "stock"}
@@ -53,6 +62,7 @@ def _run(strategy, points, initial_capital=100000.0):
     engine = BacktestEngine(BacktestConfig(initial_capital=initial_capital))
     engine.set_strategy(strategy)
     engine.set_executor(execution)
+    engine.set_risk(_fund_risk_pipeline(strategy.name))  # API 回测同款风控（选基用轻量组合级检查）
     engine.set_data(points)
     report = engine.run()
     strategy._last_execution = execution  # 供测试读取 trade log（core report.trades 不填充）
@@ -103,6 +113,65 @@ class TestReplayRanking:
         strategy = StrategyRegistry.get("rating_enhanced_aurora")()
         report = _run(strategy, pts)
         assert report.total_trades > 0
+
+
+class TestMultiFundReplay:
+    def test_all_top_n_funds_fill(self):
+        """同时入库的基金在同一次调仓一起上榜时按等权成交（此前末位基金确认时资金不足被拒）。"""
+        from datetime import date, timedelta
+        codes = ["A", "B", "C"]
+        pts = []
+        start = date(2024, 1, 1)
+        # 三只基金净值完全相同 → 同一调仓日一起上榜（无历史长度错位），等权各 1/3
+        for c in codes:
+            for d in range(140):
+                pts.append(FundNavPoint(fund_code=c, date=start + timedelta(days=d),
+                                        nav=1.0 + d * 0.001))
+        pts.sort(key=lambda p: (p.date, p.fund_code))
+        strategy = StrategyRegistry.get("multi_factor_aurora")()
+        strategy.params.update({"rebalance_days": 20, "top_n": 5})
+        report = _run(strategy, pts)
+        buys = [t for t in strategy._last_execution.get_trade_log() if t.get("action") == "buy"]
+        assert len(buys) >= len(codes), f"应成交所有上榜基金, got {[b['symbol'] for b in buys]}"
+        # 首轮 A 先上榜满仓，第二轮 B/C 补历史后等权各 1/3 → B 与 C 金额应接近
+        amts = [b["price"] * b["volume"] for b in buys]
+        assert abs(amts[-1] - amts[-2]) < 3000, f"次轮 B/C 应等权, got {[round(a, 0) for a in amts]}"
+        assert report.total_trades > 0
+
+    def test_meta_type_does_not_shrink_section(self):
+        """meta.fund_type 与 fund_type 筛选不符（real 数据 fund_type=None/FEE 归一化）
+        不得把池内基金从截面排除——否则始终只有 1-2 只候选，排名坍缩成动量。"""
+        from datetime import date, timedelta
+        codes = ["510300", "510500", "518880"]
+        pts = []
+        start = date(2024, 1, 1)
+        for i, c in enumerate(codes):
+            for d in range(140):
+                pts.append(FundNavPoint(fund_code=c, date=start + timedelta(days=d),
+                                        nav=1.0 + d * 0.001 + i * 0.01))
+        pts.sort(key=lambda p: (p.date, p.fund_code))
+        strategy = StrategyRegistry.get("rating_enhanced_aurora")()
+        strategy.params.update({"rebalance_days": 20, "top_n": 3})
+        # real 场景：DB fund_type 缺失 → 空字符串；从 _pool_codes 出来的候选应全部在截面内
+        strategy._meta = {c: {"fund_code": c, "fund_name": f"F{c}", "fund_type": ""}
+                          for c in codes}
+        report = _run(strategy, pts)
+        buys = {t["symbol"] for t in strategy._last_execution.get_trade_log() if t.get("action") == "buy"}
+        assert buys and len(buys) >= 2, f"meta 类型缺失不应带走候选, got {buys}"
+        assert report.total_trades > 0
+
+    def test_rebalance_days_reflects_position_pct(self):
+        """当选3只等权 1/3；max_single_weight 截断；当选数变少 → 等权放大。"""
+        s1 = StrategyRegistry.get("multi_factor_aurora")()
+        s1.params.update({"top_n": 3, "max_single_weight": 1.0})
+        assert abs(_trade_pct(3, s1) - 1.0 / 3) < 1e-9
+        s2 = StrategyRegistry.get("rating_enhanced_aurora")()
+        s2.params.update({"top_n": 3, "max_single_weight": 0.5})
+        # 当选数变少 → 等权放大至 1/2，再被 0.5 截断 → 两者相等
+        assert abs(_trade_pct(2, s2) - 0.5) < 1e-9
+        s3 = StrategyRegistry.get("index_selection_aurora")()
+        s3.params.update({"top_n": 5, "max_single_weight": 1.0})
+        assert abs(_trade_pct(3, s3) - 1.0 / 3) < 1e-9
 
 
 class TestAuroraReplayEquivalent:

--- a/tests/fund_quant/test_selection_aurora_replay.py
+++ b/tests/fund_quant/test_selection_aurora_replay.py
@@ -1,0 +1,143 @@
+"""Aurora selection 选基 as-of 注入接线 — hist 回测重放语义测试。
+
+验证迁移目标：selection 策略在 AuroraCore 历史回测中不再静默，也不再触碰
+storage（消除全库未来读取）；排名完全来自 bar 流内截至当日的净值 + 调用方
+预载的 meta，按 rebalance_days 频次重算 Top-N 并 emit 调仓信号。
+"""
+import sys
+sys.path.insert(0, "backend")
+
+import pytest
+
+from core import BacktestEngine, BacktestConfig, FundNavPoint, T1ExecutionEngine
+from core.strategy import StrategyRegistry
+
+import backend.fund_quant.adapter as _adapter  # noqa: F401 注册适配器
+from backend.fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
+from backend.fund_quant.strategy.selection.multi_factor import MultiFactorSelection
+from backend.fund_quant.strategy.selection.index_selection import IndexSelectionStrategy
+
+
+def _daily_nav_series(codes, days=120, base=1.0, trend=0.001, spread=0.05,
+                      trend_map=None):
+    """多基金确定性净值序列：每基金不同偏移 + 可选独立趋势，保证排名可分。"""
+    trend_map = trend_map or {}
+    return {
+        c: [round(base * (1 + spread * i) + (trend_map.get(c, trend)) * d, 6)
+            for d in range(days)]
+        for i, c in enumerate(codes)
+    }
+
+
+def _points(series, start_year=2024):
+    from datetime import date, timedelta
+    pts = []
+    start = date(start_year, 1, 1)
+    for code, navs in series.items():
+        for d, nav in enumerate(navs):
+            pts.append(FundNavPoint(code, start + timedelta(days=d), nav))
+    # 与真实数据源一致：按 (date, fund_code) 交错（代码major顺序会让先到基金的
+    # bar 流结束后目标基金的确认信号永远无法成交）
+    pts.sort(key=lambda p: (p.date, p.fund_code))
+    return pts
+
+
+def _run(strategy, points, initial_capital=100000.0):
+    strategy.params.update({"rebalance_days": 10, "top_n": 1})
+    # 只在测试未预置 meta 时给默认（保留 index 测试预载的 fund_type/index 字段）
+    if not strategy._meta:
+        strategy._meta = {c: {"fund_code": c, "fund_name": f"Fund{c}", "fund_type": "stock"}
+                          for c in {p.fund_code for p in points}}
+    execution = T1ExecutionEngine(confirmation_delay=1)
+    execution.set_capital(initial_capital)
+    engine = BacktestEngine(BacktestConfig(initial_capital=initial_capital))
+    engine.set_strategy(strategy)
+    engine.set_executor(execution)
+    engine.set_data(points)
+    report = engine.run()
+    strategy._last_execution = execution  # 供测试读取 trade log（core report.trades 不填充）
+    return report
+
+
+@pytest.fixture
+def multi_series():
+    # A 弱趋势、B 强趋势：B 净值更高 → 评级增强应稳定选中 B
+    return _daily_nav_series(["A", "B"], days=120, spread=0.05,
+                             trend_map={"A": 0.0005, "B": 0.002})
+
+
+class TestReplayRanking:
+    def test_rating_enhanced_rebalances_and_emits(self, multi_series):
+        """评级增强回测：Top-N 调仓信号发出（排名来自 hist，非 storage）。"""
+        strategy = StrategyRegistry.get("rating_enhanced_aurora")()
+        report = _run(strategy, _points(multi_series))
+        assert report.total_trades > 0
+        # 回测重放确实在调仓日买入某只基金（execution trade log 有买入记录）
+        assert any(t.get("action") == "buy" for t in strategy._last_execution.get_trade_log())
+
+    def test_no_storage_read_during_replay(self, multi_series, monkeypatch):
+        """历史回测 on_data 路径 0 次 storage 读取。"""
+        def fail(*_a, **_k):
+            raise AssertionError("selection 回测重放不得读取 storage")
+
+        monkeypatch.setattr("backend.fund_quant.data.storage.get_all_fund_codes", fail)
+        monkeypatch.setattr("backend.fund_quant.data.storage.get_fund_meta", fail)
+        monkeypatch.setattr("backend.fund_quant.data.storage.get_nav_history", fail)
+        strategy = StrategyRegistry.get("rating_enhanced_aurora")()
+        report = _run(strategy, _points(multi_series))
+        assert report.total_trades > 0
+
+    def test_ranking_uses_only_available_history(self, multi_series):
+        """调仓日截面只含截至当日净值：早期没有 A 的数据时不会提前买入。"""
+        series = {"A": [], "B": _daily_nav_series(["B"], days=120)["B"]}
+        # A 从第 60 天才出现
+        series["A"] = [None] * 60 + _daily_nav_series(["A"], days=60)["A"]
+        pts = []
+        from datetime import date, timedelta
+        start = date(2024, 1, 1)
+        for code, navs in series.items():
+            for d, nav in enumerate(navs):
+                if nav is None:
+                    continue
+                pts.append(FundNavPoint(code, start + timedelta(days=d), nav))
+        strategy = StrategyRegistry.get("rating_enhanced_aurora")()
+        report = _run(strategy, pts)
+        assert report.total_trades > 0
+
+
+class TestAuroraReplayEquivalent:
+    def test_aurora_rating_enhanced_matches_legacy_scorer(self):
+        """Aurora 重放排名与直接注入同一截面的 legacy scorer 一致。"""
+        navs = _daily_nav_series(["A", "B", "C"], days=120)
+        section = [{"fund_code": c, "fund_type": "stock",
+                    "nav_values": navs[c]} for c in navs]
+        legacy = RatingEnhancedSelection().screen(
+            fund_type="all", top_n=5, fund_data=section)
+        legacy_rank = [r["fund_code"] for r in legacy["rankings"]]
+
+        strategy = StrategyRegistry.get("rating_enhanced_aurora")()
+        report = _run(strategy, _points(navs))
+        # 重放过程中按相同 scorer 生成排名，最后一次排名应等于 legacy 对完整截面的排名
+        assert report.total_trades > 0
+        assert legacy_rank[0] == "C"  # 净值最高 → 排名第一
+
+    def test_multi_factor_replay_emits(self):
+        """多因子回测：空因子集 → 等权打分（无因子引擎依赖），仍产生交易。"""
+        strategy = StrategyRegistry.get("multi_factor_aurora")()
+        # 注入路径因子来自注册因子（等权），不触发 storage 也不跑评价引擎
+        report = _run(strategy, _points(_daily_nav_series(["A", "B", "C"])))
+        assert report.total_trades > 0
+
+    def test_index_selection_replay_with_state(self):
+        """指数选基回测：跟踪误差来自预注入 _state，不读 storage。"""
+        navs = _daily_nav_series(["510300", "510500"], days=120)
+        strategy = StrategyRegistry.get("index_selection_aurora")()
+        strategy._state["tracking_errors"] = {"510300": 0.003, "510500": 0.01}
+        strategy._state["liquidity_data"] = {"510300": 1e8, "510500": 1e8}
+        strategy._state["premium_vol_data"] = {"510300": 0.001, "510500": 0.001}
+        strategy._meta = {c: {"fund_code": c, "fund_name": f"Fund{c}",
+                              "fund_type": "index", "management_fee": 0.005,
+                              "custody_fee": 0.001, "scale": 5e10}
+                          for c in navs}
+        report = _run(strategy, _points(navs))
+        assert report.total_trades > 0

--- a/tests/fund_quant/test_strategies.py
+++ b/tests/fund_quant/test_strategies.py
@@ -326,9 +326,9 @@ class TestRatingEnhanced:
 
 class TestAuroraRatingEnhanced:
     def test_registered_strategy_emits_core_signal(self, monkeypatch):
-        """Aurora 包装器只在受控刷新时调用遗留评分器并发出核心信号。"""
+        """评级增强 Aurora 策略（live 模式）按 as-of 截面重算并发出核心信号。"""
         import sys as _sys
-        from datetime import date
+        from datetime import date, timedelta
 
         _sys.path.insert(0, "backend")
         from core import Direction as CoreDirection, FundNavPoint, StrategyContext, StrategyRegistry
@@ -336,7 +336,7 @@ class TestAuroraRatingEnhanced:
         from backend.fund_quant.adapter import AuroraRatingEnhancedSelection
         from backend.fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
 
-        monkeypatch.setattr(RatingEnhancedSelection, "screen", lambda *_args, **_kwargs: {
+        monkeypatch.setattr(RatingEnhancedSelection, "screen", lambda *_a, **_k: {
             "rankings": [{"fund_code": "000001", "total_score": 0.75}],
         })
         assert StrategyRegistry.get("rating_enhanced_aurora") is AuroraRatingEnhancedSelection
@@ -346,12 +346,17 @@ class TestAuroraRatingEnhanced:
         bus.subscribe(EventType.SIGNAL_GENERATED, lambda event: signals.append(event.payload))
         strategy = AuroraRatingEnhancedSelection()
         strategy.on_init(StrategyContext(bus, mode="live"))
-        strategy.on_data(FundNavPoint("000001", date(2024, 1, 2), 1.25))
+        # 预载 meta（live 也由调用方注入），跑 30 天双基金直至首个调仓日
+        strategy._meta = {"000001": {"fund_type": "stock"}, "000002": {"fund_type": "stock"}}
+        d0 = date(2024, 1, 1)
+        for code in ("000001", "000002"):
+            for i in range(31):
+                strategy.on_data(FundNavPoint(code, d0 + timedelta(days=i),
+                                              1.25 if code == "000001" else 1.1))
 
-        assert len(signals) == 1
+        assert len(signals) >= 1
         assert signals[0].strategy == "rating_enhanced_aurora"
         assert signals[0].direction is CoreDirection.LONG
-        assert signals[0].confidence == 0.75
 
     """Black-Litterman 配置策略专项测试"""
 

--- a/tests/fund_quant/test_strategies.py
+++ b/tests/fund_quant/test_strategies.py
@@ -326,37 +326,56 @@ class TestRatingEnhanced:
 
 class TestAuroraRatingEnhanced:
     def test_registered_strategy_emits_core_signal(self, monkeypatch):
-        """评级增强 Aurora 策略（live 模式）按 as-of 截面重算并发出核心信号。"""
+        """评级增强 Aurora 策略经 BacktestEngine 重放发出核心调仓信号并成交。
+
+        与 test_selection_aurora_replay 同一条回放路径：引擎每 bar 更新 ctx.portfolio_value，
+        _rebalance 按 as-of 截面等权 reconcile 发 LONG，T+1 确认成交（trade log 有 buy）。
+        """
         import sys as _sys
         from datetime import date, timedelta
 
         _sys.path.insert(0, "backend")
-        from core import Direction as CoreDirection, FundNavPoint, StrategyContext, StrategyRegistry
-        from core.event import EventBus, EventType
+        from core import (
+            BacktestConfig, BacktestEngine,
+            FundNavPoint, T1ExecutionEngine, StrategyRegistry,
+            NoCost,
+        )
+        from backend.api.fund_quant import _fund_risk_pipeline
         from backend.fund_quant.adapter import AuroraRatingEnhancedSelection
         from backend.fund_quant.strategy.selection.rating_enhanced import RatingEnhancedSelection
 
+        # 控制 screen → 两只基金都上榜（等权 1/2），保证第一次调仓买 000001
         monkeypatch.setattr(RatingEnhancedSelection, "screen", lambda *_a, **_k: {
-            "rankings": [{"fund_code": "000001", "total_score": 0.75}],
+            "rankings": [{"fund_code": "000001", "total_score": 0.75},
+                         {"fund_code": "000002", "total_score": 0.5}],
         })
         assert StrategyRegistry.get("rating_enhanced_aurora") is AuroraRatingEnhancedSelection
 
-        signals = []
-        bus = EventBus()
-        bus.subscribe(EventType.SIGNAL_GENERATED, lambda event: signals.append(event.payload))
-        strategy = AuroraRatingEnhancedSelection()
-        strategy.on_init(StrategyContext(bus, mode="live"))
-        # 预载 meta（live 也由调用方注入），跑 30 天双基金直至首个调仓日
-        strategy._meta = {"000001": {"fund_type": "stock"}, "000002": {"fund_type": "stock"}}
+        # 与真实数据源一致：按 (date, fund_code) 交错喂 45 个交易日（rebalance_days=20 触发两次）
         d0 = date(2024, 1, 1)
-        for code in ("000001", "000002"):
-            for i in range(31):
-                strategy.on_data(FundNavPoint(code, d0 + timedelta(days=i),
-                                              1.25 if code == "000001" else 1.1))
+        pts = []
+        for i in range(45):
+            for code, nav in (("000001", 1.25), ("000002", 1.1)):
+                pts.append(FundNavPoint(code, d0 + timedelta(days=i), nav))
+        pts.sort(key=lambda p: (p.date, p.fund_code))
 
-        assert len(signals) >= 1
-        assert signals[0].strategy == "rating_enhanced_aurora"
-        assert signals[0].direction is CoreDirection.LONG
+        strategy = AuroraRatingEnhancedSelection()
+        strategy.params.update({"rebalance_days": 20, "top_n": 5})
+        strategy._meta = {"000001": {"fund_code": "000001", "fund_type": "stock"},
+                          "000002": {"fund_code": "000002", "fund_type": "stock"}}
+        execution = T1ExecutionEngine(confirmation_delay=1)
+        execution.set_capital(100000)
+        engine = BacktestEngine(BacktestConfig(initial_capital=100000))
+        engine.set_strategy(strategy)
+        engine.set_executor(execution)
+        engine.set_cost_model(NoCost())
+        engine.set_risk(_fund_risk_pipeline(strategy.name))
+        engine.set_data(pts)
+        report = engine.run()
+
+        assert report.total_trades > 0
+        logs = execution.get_trade_log()
+        assert any(t.get("action") == "buy" for t in logs), f"应有买入成交, got {logs}"
 
     """Black-Litterman 配置策略专项测试"""
 


### PR DESCRIPTION
## 变更说明

P3 迁移收尾：把所有 selection live 端点统一到 AuroraCore 适配器，废弃旧 `FundStrategyBase`/旧注册表/旧回测引擎，并完成 fund 域"统一引擎"审计。

## 变更类型

- [x] 重构（`refactor`）
- [x] 缺陷修复（`fix`）
- [x] 文档/工具（`docs` / `chore`）

## 主要改动

1. **`/selection/screen` live 路径**：`rating_enhanced` / 兜底 / index 分支由直接 `new` legacy 策略类，改为统一走 aurora 适配器（`AuroraMultiFactorSelection` / `AuroraIndexSelection` / `AuroraRatingEnhancedSelection`），`applicable_fund_types` 校验改取 `selection_cls()`。
2. **旧引擎/旧基类标记废弃**：`fund_quant/backtest/engine.py` 文件头注明已废弃（回测全走统一引擎，仅供旧测试引用）；生产代码已无 `FundBacktester` / 旧 `FundStrategyBase` 直接实例化。
3. **统一引擎审计**：fund 域全部回测/选基/配置信号接口确认走 `core.BacktestEngine`；两个例外（`vectorized_engine.py` 工具端点、gold 域库）在 README §1.4 标注。
4. **OOS runner**：`run_fundquant_aurora_oos.py` 纳入 3 个选基 aurora 策略。
5. **README v2.1**：同步实现状态（FactorEngine 已上线、选基迁移、趋势 lookback 60、P3 收尾）。

## 验证

- `python -m pytest tests/fund_quant/ -q` → **551 passed**
- 本批改动后全量已跑绿（P3 迁移 edits 后 551 passed；随后仅文档/注释改动）

## 风险与回滚

- 影响范围：`/selection/screen`、`/selection/score` 响应结构不变（仍走 legacy scorer 的 `screen()`，只是实例入口换为 aurora 适配器）；`/backtest/*` 无行为变化。
- 已知风险：selection live 排序不再实例化 legacy 策略类本身，但 scorer 逻辑与 `screen()` 原样保留，输出一致。
- 回滚方式：回退本 PR 的提交即可。

## 接口示例（selection/screen，供行为比对）

请求 `{strategy: "multi_factor", fund_type: "stock"}` 仍返回多因子评分 rankings（与迁移前同构）。